### PR TITLE
Fix: Adds container param to existing tooltips

### DIFF
--- a/_dev/src/components/free-listing/free-listing-card.vue
+++ b/_dev/src/components/free-listing/free-listing-card.vue
@@ -115,7 +115,7 @@
       <ul class="list-inline mb-0">
         <li
           class="list-inline-item"
-          v-b-tooltip.hover
+          v-b-tooltip:googleShoppingApp.hover
           title="Tooltip directive content"
         >
           <b-badge
@@ -126,7 +126,7 @@
         </li>
         <li
           class="list-inline-item"
-          v-b-tooltip.hover
+          v-b-tooltip:googleShoppingApp.hover
           title="Tooltip directive content"
         >
           <b-badge

--- a/_dev/src/components/product-feed/product-feed-card-report-products-card.vue
+++ b/_dev/src/components/product-feed/product-feed-card-report-products-card.vue
@@ -11,7 +11,7 @@
         <b-button
           variant="invisible"
           class="p-0 mt-0 ml-1"
-          v-b-tooltip.hover
+          v-b-tooltip:googleShoppingApp.hover
           :title="badgeTooltip"
         >
           <b-icon-exclamation-circle

--- a/_dev/src/components/product-feed/product-feed-card.vue
+++ b/_dev/src/components/product-feed/product-feed-card.vue
@@ -58,7 +58,7 @@
       <ul class="list-inline mb-0">
         <li
           class="list-inline-item"
-          v-b-tooltip.hover
+          v-b-tooltip:googleShoppingApp.hover
           title="Tooltip directive content"
         >
           <b-badge variant="muted">
@@ -67,7 +67,7 @@
         </li>
         <li
           class="list-inline-item"
-          v-b-tooltip.hover
+          v-b-tooltip:googleShoppingApp.hover
           title="Tooltip directive content"
         >
           <b-badge variant="muted">

--- a/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-card.vue
+++ b/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-card.vue
@@ -46,7 +46,7 @@
       <ul class="list-inline mb-0">
         <li
           class="list-inline-item"
-          v-b-tooltip.hover
+          v-b-tooltip:googleShoppingApp.hover
           title="Tooltip directive content"
         >
           <b-badge
@@ -57,7 +57,7 @@
         </li>
         <li
           class="list-inline-item"
-          v-b-tooltip.hover
+          v-b-tooltip:googleShoppingApp.hover
           title="Tooltip directive content"
         >
           <b-badge


### PR DESCRIPTION
In order to have the css for the tooltips, we need top add the container parameter to the tooltips directive.