### PR TITLE
Use double quotes in glass content so carriage returns are displayed properly

### DIFF
--- a/classes/Translations/PsGoogleShoppingTranslations.php
+++ b/classes/Translations/PsGoogleShoppingTranslations.php
@@ -298,7 +298,7 @@ class PsGoogleShoppingTranslations
                 'noFaq' => $this->module->l('No FAQ available.', 'PsGoogleShoppingTranslations'),
             ],
             'glass' => [
-                'message' => $this->module->l('Can\'t see Google secured browser?  \nHit Continue to relaunch the window and finish configuration.\n\nYou may need to activate popups in your browser to continue.', 'PsGoogleShoppingTranslations'),
+                'message' => $this->module->l("Can't see Google secured browser?  \nHit Continue to relaunch the window and finish configuration.\n\nYou may need to activate popups in your browser to continue.", 'PsGoogleShoppingTranslations'),
             ],
             'cta' => [
                 'getStarted' => $this->module->l('Get started', 'PsGoogleShoppingTranslations'),


### PR DESCRIPTION
Reported by @jokesterfr 

![image](https://user-images.githubusercontent.com/6768917/119120314-0d520480-ba24-11eb-82d9-7e0bc56a6ff2.png)
