### PR TITLE
GMC list: Check the user email is the current google account one to set the admin flag

### DIFF
--- a/_dev/src/components/merchant-center-account/merchant-center-account-card.vue
+++ b/_dev/src/components/merchant-center-account/merchant-center-account-card.vue
@@ -365,8 +365,13 @@ export default {
     isMcaUserAdmin(index) {
       let isAdmin = false;
       this.mcaSelectionOptions[index].users.forEach((user) => {
-        // ToDo: We may need to check if the email is the same as
-        // the google account one
+        // Only continue if the user email matches the onboarded Google Account one
+        if (this.$store.state.accounts.googleAccount.details.email
+        && user.emailAddress
+        && this.$store.state.accounts.googleAccount.details.email !== user.emailAddress) {
+          return;
+        }
+
         isAdmin = user.admin || isAdmin;
       });
       return isAdmin;


### PR DESCRIPTION
Note: In case the email of the google account is not set, or if the GMC one is not provided, the check won't happen. This can lead to accounts being allowed for selection while they shouldn't.