### PR TITLE
Set default URL to manage Google Account

### DIFF
--- a/_dev/src/assets/json/googleUrl.json
+++ b/_dev/src/assets/json/googleUrl.json
@@ -9,5 +9,6 @@
   "returnPolicy" : "//google.com",
   "billingTerms" : "//google.com",
   "completeCheckoutProcess" : "//google.com",
-  "policyAdultContent" : "//google.com"
+  "policyAdultContent" : "//google.com",
+  "manageGoogleAccount" : "https://myaccount.google.com/"
 }

--- a/_dev/src/assets/scss/base/_common.scss
+++ b/_dev/src/assets/scss/base/_common.scss
@@ -6,16 +6,18 @@ a[target="_blank"].text-muted {
 }
 
 a[target="_blank"] {
-  text-decoration: underline;
-
-  &:hover,
-  &:focus {
-    color: $blue;
-  }
-
-  &:active,
-  &:visited {
-    color: $blue_dark;
+  &:not(.btn) {
+    text-decoration: underline;
+  
+    &:hover,
+    &:focus {
+      color: $blue;
+    }
+  
+    &:active,
+    &:visited {
+      color: $blue_dark;
+    }
   }
 
   &::after {

--- a/_dev/src/components/google-account/google-account-card.vue
+++ b/_dev/src/components/google-account/google-account-card.vue
@@ -115,6 +115,8 @@
             size="sm"
             variant="outline-secondary"
             class="mx-1 mt-3 mt-md-0 mr-md-0"
+            :href="$options.googleUrl.manageGoogleAccount"
+            target="_blank"
           >
             {{ $t('cta.manageAccount') }}
           </b-button>
@@ -133,6 +135,7 @@
 </template>
 
 <script>
+import googleUrl from '@/assets/json/googleUrl.json';
 
 import {
   BIconstack,
@@ -251,6 +254,7 @@ export default {
       this.$emit('dissociateGoogleAccount');
     },
   },
+  googleUrl,
 };
 </script>
 


### PR DESCRIPTION
@amaury-hanser, I had to modify _dev/src/assets/scss/base/_common.scss to allow the button keeping their original attributes when using links:

![image](https://user-images.githubusercontent.com/6768917/119868617-2d4b6180-bf17-11eb-8dfd-9098835fd201.png)
