### PR TITLE
Fix icon not appearing in safari

### DIFF
--- a/_dev/src/assets/scss/base/_common.scss
+++ b/_dev/src/assets/scss/base/_common.scss
@@ -21,7 +21,7 @@ a[target="_blank"] {
       color: $blue !important;
     }
     &::after {
-      content: "launch";
+      content: "\e895"; // "launch" icon
       font-family: 'Material Icons';
       -webkit-font-feature-settings: 'liga';
       display: inline-block;

--- a/_dev/src/assets/scss/components/_landingpageheader.scss
+++ b/_dev/src/assets/scss/components/_landingpageheader.scss
@@ -20,7 +20,7 @@
       }
 
       &::before {
-        content: "done";
+        content: "\e876"; // "done" icon
         display: inline-block;
         vertical-align: middle;
         margin-right: rem(8);


### PR DESCRIPTION
Had to make some changes when we use material icon in a pseudo element. Using it's name won't work in safari, we need to use it's code point.

```
      &::before {
        content: "done";
        ...
      }
```
to:
```
      &::before {
        content: "\e876"; // "done" icon
        ...
      }
```