### PR TITLE
Updates product-feed mock for storybook as we were overwriting state

### DIFF
--- a/_dev/.storybook/mock/product-feed.js
+++ b/_dev/.storybook/mock/product-feed.js
@@ -31,14 +31,8 @@ export const productFeed = {
 export const productFeedEnabled = {
   ...productFeed,
   status: {
+    ...productFeed.status,
     enabled: true,
-  }
-}
-
-export const productFeedDisabled = {
-  ...productFeed,
-  status: {
-    enabled: false,
   }
 }
 
@@ -51,12 +45,12 @@ export const productFeedIsConfigured = {
 export const productFeedMissingFields = {
   ...productFeedIsConfigured,
   settings: {
+    ...productFeedIsConfigured.settings,
     targetCountries: [],
     attributeMapping: {},
     autoImportShippingSettings: false,
   }
 }
-
 
 export const productFeedIsConfiguredOnce = {
   ...productFeedIsConfigured,
@@ -66,6 +60,7 @@ export const productFeedIsConfiguredOnce = {
 export const productFeedStatusSyncFailed = {
   ...productFeedEnabled,
   status: {
+    ...productFeedEnabled.status,
     failedSyncs: ['fail'],
   }
 }


### PR DESCRIPTION
We hade to rewrite the product-feed mock as we were overwriting the state in a wrong way:

**This**
```
export const productFeedEnabled = {
  ...productFeed,
  status: {
    enabled: true,
  }
}
```

**To this**
```
export const productFeedEnabled = {
  ...productFeed,
  status: {
    ...productFeed.status,
    enabled: true,
  }
}
```