### PR TITLE
change all statuses when unlink gmc

### DIFF
--- a/_dev/src/store/modules/accounts/mutations.ts
+++ b/_dev/src/store/modules/accounts/mutations.ts
@@ -88,6 +88,14 @@ export default {
       ...state.googleMerchantAccount,
       id: null,
       gmcStatus: null,
+      isVerified: false,
+      isClaimed: false,
+      isSuspended: {
+        status: false,
+      },
+      isEnhancedFreeListingCompliant: {
+        status: true,
+      },
     };
   },
   [MutationsTypes.SAVE_WEBSITE_VERIFICATION_AND_CLAIMING_STATUS](


### PR DESCRIPTION
It was missing the changing statuses on `isClaimed`, `isVerified` etc when GMC was unlinked