### PR TITLE
Manage case if export product feed does not work

### DIFF
--- a/_dev/src/components/free-listing/free-listing-card.vue
+++ b/_dev/src/components/free-listing/free-listing-card.vue
@@ -57,7 +57,6 @@
     </div>
     <p
       class="ps_gs-fz-14 mb-2"
-      v-if="!isEnabled"
     >
       {{ $t('freeListingCard.intro') }}
     </p>

--- a/_dev/src/components/product-feed/product-feed-card.vue
+++ b/_dev/src/components/product-feed/product-feed-card.vue
@@ -32,7 +32,7 @@
       v-if="!isEnabled"
       :badges="['merchantCenterAccount']"
     />
-    <div v-if="isEnabled && toConfigure">
+    <div v-if="(isEnabled && toConfigure) || isErrorApi">
       <p>
         {{ $t("productFeedCard.introToConfigure") }}<br>
         <a
@@ -85,7 +85,7 @@
         </div>
       </b-alert>
     </div>
-    <div v-if="isEnabled && !toConfigure">
+    <div v-if="isEnabled && !toConfigure && !isErrorApi">
       <b-alert
         variant="warning"
         :show="!!alert && alert !== 'ShippingSettingsMissing'"

--- a/_dev/src/components/product-feed/product-feed-settings-summary.vue
+++ b/_dev/src/components/product-feed/product-feed-settings-summary.vue
@@ -248,8 +248,6 @@ export default {
     },
     postDatas() {
       this.$store.dispatch('productFeed/SEND_PRODUCT_FEED_SETTINGS');
-      this.$store.commit('productFeed/TOGGLE_CONFIGURATION_FINISHED', true);
-      this.$store.commit('productFeed/SAVE_CONFIGURATION_CONNECTED_ONCE', true);
       this.$router.push({
         path: '/configuration',
       });

--- a/_dev/src/store/modules/product-feed/actions.ts
+++ b/_dev/src/store/modules/product-feed/actions.ts
@@ -150,6 +150,8 @@ export default {
         throw new HttpClientError(response.statusText, response.status);
       }
       response.json();
+      commit(MutationsTypes.TOGGLE_CONFIGURATION_FINISHED, true);
+      commit(MutationsTypes.SAVE_CONFIGURATION_CONNECTED_ONCE, true);
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
+ Modify card to display the right error if product feed has not been exported correctly (api error)
+ Add intro in free listing card in every cases and not only when it was not enabled because the card was empty without the alert (Lola's request)