### PR TITLE
Removes duplicate toaster in SB

### DIFF
--- a/_dev/.storybook/preview.js
+++ b/_dev/.storybook/preview.js
@@ -59,8 +59,23 @@ const locales = Object.keys(messages);
 Vue.use(VueI18n);
 Vue.use(Vuex);
 
-addDecorator(() => ({
-  template: `
+addDecorator((story, context) => ({
+  template: context.parameters.component === "OnboardingPage" ?
+  `
+   <div
+     class='nobootstrap'
+     style='
+       background: none;
+       padding: 0;
+       min-width: 0;
+   '>
+     <div id='psxMktgWithGoogleApp'>
+       <story />
+     </div>
+   </div>
+   `
+   :
+   `
    <div
      class='nobootstrap'
      style='
@@ -78,7 +93,8 @@ addDecorator(() => ({
        <story />
      </div>
    </div>
-   `,
+   `
+   ,
   i18n: new VueI18n({
     defaultLocale: 'en',
     locale: 'en',

--- a/_dev/stories/onboarding-page.stories.ts
+++ b/_dev/stories/onboarding-page.stories.ts
@@ -8,6 +8,7 @@ import Actions from '../.storybook/mock/actions-accounts';
 
 export default {
   title: 'Onboarding/OnboardingPage',
+  component: 'OnboardingPage',
 };
 
 const TemplatePsAccount = (args, { argTypes }) => ({

--- a/_dev/stories/toast.stories.ts
+++ b/_dev/stories/toast.stories.ts
@@ -10,7 +10,6 @@ const Template = (args, { argTypes }) => ({
   components: { PsToast },
   template: `
     <div>
-      <b-toaster name="b-toaster-top-right" class="ps_gs-toaster-top-right"/>
       <ps-toast
         variant="success"
         :visible="visible"


### PR DESCRIPTION
Changes `preview.js` to use a differente template if we are on the onboarding page or not, to add the toaster only if we are not on the onboarding page.

![image](https://user-images.githubusercontent.com/25964813/126643960-9b4362c4-51b3-4fb6-a127-583dc6dcfa08.png)
