### PR TITLE
Removes unwanted style on psaccount card

### DIFF
--- a/_dev/src/assets/scss/base/_common.scss
+++ b/_dev/src/assets/scss/base/_common.scss
@@ -33,7 +33,7 @@ a[target="_blank"].text-muted:not(.external_link-no_icon) {
 }
 
 .ps_gs-ps-account-card a[target="_blank"]:after {
-  content: none;
+  content: none !important;
 }
 
 .icon-busy {


### PR DESCRIPTION
Removes the icon before the cog
![image](https://user-images.githubusercontent.com/25964813/126645346-fc07deb5-b6fd-44af-8f06-6e751717ea39.png)
