### PR TITLE
Adds few tests to free listing card

### DIFF
--- a/_dev/src/components/free-listing/free-listing-card.spec.ts
+++ b/_dev/src/components/free-listing/free-listing-card.spec.ts
@@ -25,6 +25,12 @@ describe('free-listing.vue / disabled', () => {
 });
 
 describe('free-listing.vue / enabled', () => {
+  let mockRouter;
+
+  beforeEach(() => {
+    mockRouter = {go: jest.fn()};
+  });
+
   it('switch is shown when card is enabled', () => {
     const wrapper = shallowMount(FreeListingCard, {
       propsData: {
@@ -52,5 +58,28 @@ describe('free-listing.vue / enabled', () => {
 
     // Check if toggle switch is disabled
     expect(wrapper.find('.ps-switch [type="radio"]').attributes('disabled')).toBe('disabled');
+  });
+
+  it('refresh button available when there is an API error and calls refresh function', async () => {
+    const wrapper = shallowMount(FreeListingCard, {
+      mocks: {
+        $router: mockRouter,
+      },
+      propsData: {
+        isEnabled: true,
+      },
+      ...commonOptions,
+      store: new Vuex.Store(cloneStore()),
+      beforeMount(this: any) {
+        this.$store.state.freeListing.errorAPI = true;
+      },
+    });
+
+    // Check if refresh button exists
+    expect(wrapper.find('[data-test-id="btn-refresh"]').exists()).toBeTruthy();
+
+    // Check if $router.go() has been called when refresh btn is clicked
+    await wrapper.find('[data-test-id="btn-refresh"]').trigger('click');
+    expect(mockRouter.go).toHaveBeenCalledTimes(1);
   });
 });

--- a/_dev/src/components/free-listing/free-listing-card.vue
+++ b/_dev/src/components/free-listing/free-listing-card.vue
@@ -80,6 +80,7 @@
             class="mx-1 mt-3 mt-md-0 ml-md-0 mr-md-1"
             variant="outline-secondary"
             @click="refresh"
+            data-test-id="btn-refresh"
           >
             {{ $t('general.refreshPage') }}
           </b-button>


### PR DESCRIPTION
- switch is disabled when there is an API error
- refresh button available when there is an API error and calls refresh function