### PR TITLE
Adds webpack config to remove data-test-id attribute during build

### DIFF
--- a/_dev/vue.config.js
+++ b/_dev/vue.config.js
@@ -24,6 +24,27 @@ module.exports = {
     config.plugins.delete('preload');
     config.plugins.delete('prefetch');
     config.resolve.alias.set('@', path.resolve(__dirname, 'src'));
+    config.module
+      .rule('vue')
+      .use('vue-loader')
+      .tap((options) => {
+        options.compilerOptions.modules = [
+          {
+            preTransformNode(astEl) {
+              if (process.env.NODE_ENV === 'production') {
+                const {attrsMap, attrsList} = astEl;
+                if (attrsMap['data-test-id']) {
+                  delete attrsMap['data-test-id'];
+                  const index = attrsList.findIndex((x) => x.name === 'data-test-id');
+                  attrsList.splice(index, 1);
+                }
+              }
+              return astEl;
+            },
+          },
+        ];
+        return options;
+      });
   },
   css: {
     extract: false,


### PR DESCRIPTION
It allows us to add an attribute `data-test-id` in the dom:
```
  <h2
    class="ps_gs-section-title"
    data-test-id="tutu"
    :class="{ 'ps_gs-section-title--disabled' : !isEnabled }"
  >
```
That we can target in our _**jest tests**_.
```
    expect(wrapper.find('[data-test-id="tutu"]').exists()).toBeTruthy();
```
The attribute will be removed during build time for production.