### PR TITLE
Fix missing window.i18nSettings.languageLocale

### DIFF
--- a/_dev/.storybook/preview.js
+++ b/_dev/.storybook/preview.js
@@ -121,6 +121,11 @@ addDecorator((story, context) => ({
       },
       immediate: true,
     },
+    beforeCreate: () => {
+      window.i18nSettings = {
+        languageLocale: 'en' // needed in _dev/src/store/modules/product-feed/actions.ts
+      }
+    },
   },
   store: new Vuex.Store(cloneStore()),
 }));


### PR DESCRIPTION
In the module, the variable comes from php, in Storybook, we need to define it explicitly.