### PR TITLE
Request new oauth url for all HTTP error codes

### DIFF
--- a/_dev/src/store/modules/accounts/actions.ts
+++ b/_dev/src/store/modules/accounts/actions.ts
@@ -214,9 +214,9 @@ export default {
       dispatch(ActionsTypes.REQUEST_GMC_LIST);
       return json;
     } catch (error) {
+      dispatch(ActionsTypes.REQUEST_ROUTE_TO_GOOGLE_AUTH);
       if (error instanceof HttpClientError && (error.code === 404 || error.code === 412)) {
         // This is likely caused by a missing Google account, so let's retrieve the URL
-        dispatch(ActionsTypes.REQUEST_ROUTE_TO_GOOGLE_AUTH);
         return null;
       }
       console.error(`Could not request google account details: ${(<any>error)?.message}`);


### PR DESCRIPTION
In some cases, we display a warning message on the Google Account card saying that we couldn't retrieve details of the current account and keep the button clickable.

In this case, restarting the onboarding leads to an empty onboarding page. This PR avoids this issue by requesting a new authorization url.