### PR TITLE
Fix return status when checking remarketing feature status

### DIFF
--- a/controllers/admin/AdminAjaxPsxMktgWithGoogleController.php
+++ b/controllers/admin/AdminAjaxPsxMktgWithGoogleController.php
@@ -280,7 +280,7 @@ class AdminAjaxPsxMktgWithGoogleController extends ModuleAdminController
     private function getRemarketingTagsStatus()
     {
         $this->ajaxDie(json_encode([
-            'remarketingTagsStatus' => $this->configurationAdapter->get(Config::PSX_MKTG_WITH_GOOGLE_REMARKETING_STATUS),
+            'remarketingTagsStatus' => (bool) $this->configurationAdapter->get(Config::PSX_MKTG_WITH_GOOGLE_REMARKETING_STATUS),
         ]));
     }
 

--- a/controllers/admin/AdminPsxMktgWithGoogleModuleController.php
+++ b/controllers/admin/AdminPsxMktgWithGoogleModuleController.php
@@ -143,7 +143,7 @@ class AdminPsxMktgWithGoogleModuleController extends ModuleAdminController
             'psxMktgWithGoogleActiveCountries' => $this->countryRepository->getActiveCountries(),
             'psxMtgWithGoogleDefaultShopCountry' => $this->countryRepository->getShopDefaultCountry()['iso_code'],
             'psxMktgWithGoogleShopCurrency' => $this->currencyRepository->getShopCurrency(),
-            'psxMktgWithGoogleRemarketingTagsStatus' => $this->configurationAdapter->get(Config::PSX_MKTG_WITH_GOOGLE_REMARKETING_STATUS),
+            'psxMktgWithGoogleRemarketingTagsStatus' => (bool) $this->configurationAdapter->get(Config::PSX_MKTG_WITH_GOOGLE_REMARKETING_STATUS),
         ]);
 
         $this->content = $this->context->smarty->fetch($this->module->getLocalPath() . '/views/templates/admin/app.tpl');


### PR DESCRIPTION
Make sure we return a boolean to VueJS when checking the remarketing has been already enabled