### PR TITLE
Fixes : toasts and SSC page

### DIFF
--- a/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation-popin-recap.vue
+++ b/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation-popin-recap.vue
@@ -154,7 +154,7 @@ export default {
           this.$emit('displayErrorApiWhenSavingSSC');
         } else {
           this.$router.push({
-            name: 'campaign',
+            name: 'campaign-list',
           });
           this.$emit('openPopinSSCCreated');
           this.isValidating = false;

--- a/_dev/src/router/index.ts
+++ b/_dev/src/router/index.ts
@@ -65,6 +65,11 @@ const routes: Array<RouteConfig> = [
     component: CampaignPage,
   },
   {
+    path: '/campaign/list',
+    name: 'campaign-list',
+    component: CampaignPage,
+  },
+  {
     path: '/reporting',
     name: 'reporting',
     component: ReportingPage,

--- a/_dev/src/views/campaign-page.vue
+++ b/_dev/src/views/campaign-page.vue
@@ -2,15 +2,14 @@
   <div>
     <campaign-card
       @openPopin="onOpenPopinActivateTracking"
-      v-if="$route.name === 'campaign' && !SSCExist"
+      v-if="$route.name === 'campaign'"
     />
     <smart-shopping-campaign-table-list
       :loading="loading"
-      v-if="$route.name === 'campaign'"
+      v-else-if="$route.name === 'campaign-list'"
     />
-
     <smart-shopping-campaign-creation
-      v-if="$route.name === 'campaign-creation' && !loading"
+      v-else-if="$route.name === 'campaign-creation'"
       @campaignCreated="onCampaignHasBeenCreated"
     />
     <SSCPopinActivateTracking
@@ -67,13 +66,13 @@ export default {
   },
   methods: {
     async getDatas() {
+      await this.$store.dispatch('smartShoppingCampaigns/GET_SSC_LIST').then(() => {
+        this.loading = false;
+      });
       await this.$store.dispatch('googleAds/GET_GOOGLE_ADS_ACCOUNT');
       await this.$store.dispatch('productFeed/GET_PRODUCT_FEED_SYNC_STATUS');
       await this.$store.dispatch('productFeed/GET_PRODUCT_FEED_SETTINGS');
       await this.$store.dispatch('productFeed/GET_PRODUCT_FEED_SYNC_SUMMARY');
-      await this.$store.dispatch('smartShoppingCampaigns/GET_SSC_LIST').then(() => {
-        this.loading = false;
-      });
     },
     onOpenPopinActivateTracking() {
       this.$bvModal.show(
@@ -96,6 +95,24 @@ export default {
           });
         }
       });
+  },
+  watch: {
+    $route: {
+      handler(route) {
+        if (route.name === 'campaign' && this.SSCExist) {
+          this.$router.push({
+            name: 'campaign-list',
+          });
+        }
+        this.$store.commit('accounts/SAVE_GOOGLE_ACCOUNT_CONNECTED_ONCE', false);
+        this.$store.commit('accounts/SAVE_MCA_CONNECTED_ONCE', false);
+        this.$store.commit('productFeed/SAVE_CONFIGURATION_CONNECTED_ONCE', false);
+        this.$store.commit('freeListing/SAVE_ACTIVATED_ONCE', false);
+        this.$store.commit('googleAds/SAVE_GOOGLE_ADS_ACCOUNT_CONNECTED_ONCE', false);
+      },
+      deep: true,
+      immediate: true,
+    },
   },
 };
 </script>

--- a/_dev/src/views/help.vue
+++ b/_dev/src/views/help.vue
@@ -58,6 +58,19 @@ export default defineComponent({
       });
     },
   },
+  watch: {
+    $route: {
+      handler() {
+        this.$store.commit('accounts/SAVE_GOOGLE_ACCOUNT_CONNECTED_ONCE', false);
+        this.$store.commit('accounts/SAVE_MCA_CONNECTED_ONCE', false);
+        this.$store.commit('productFeed/SAVE_CONFIGURATION_CONNECTED_ONCE', false);
+        this.$store.commit('freeListing/SAVE_ACTIVATED_ONCE', false);
+        this.$store.commit('googleAds/SAVE_GOOGLE_ADS_ACCOUNT_CONNECTED_ONCE', false);
+      },
+      deep: true,
+      immediate: true,
+    },
+  },
 });
 </script>
 

--- a/_dev/src/views/onboarding-page.vue
+++ b/_dev/src/views/onboarding-page.vue
@@ -211,7 +211,7 @@ export default {
         this.$store.commit('productFeed/SAVE_CONFIGURATION_CONNECTED_ONCE', false);
       } else if (this.freeListingIsActivatedOnce) {
         this.$store.commit('freeListing/SAVE_ACTIVATED_ONCE', false);
-      } else if (this.freeListingIsActivatedOnce) {
+      } else if (this.googleAdsAccountConnectedOnce) {
         this.$store.commit('googleAds/SAVE_GOOGLE_ADS_ACCOUNT_CONNECTED_ONCE', false);
       }
     },

--- a/_dev/src/views/product-feed-page.vue
+++ b/_dev/src/views/product-feed-page.vue
@@ -54,6 +54,20 @@ export default {
       });
   },
 
+  watch: {
+    $route: {
+      handler() {
+        this.$store.commit('accounts/SAVE_GOOGLE_ACCOUNT_CONNECTED_ONCE', false);
+        this.$store.commit('accounts/SAVE_MCA_CONNECTED_ONCE', false);
+        this.$store.commit('productFeed/SAVE_CONFIGURATION_CONNECTED_ONCE', false);
+        this.$store.commit('freeListing/SAVE_ACTIVATED_ONCE', false);
+        this.$store.commit('googleAds/SAVE_GOOGLE_ADS_ACCOUNT_CONNECTED_ONCE', false);
+      },
+      deep: true,
+      immediate: true,
+    },
+  },
+
 };
 </script>
 

--- a/_dev/src/views/reporting-page.vue
+++ b/_dev/src/views/reporting-page.vue
@@ -45,5 +45,18 @@ export default {
         }
       });
   },
+  watch: {
+    $route: {
+      handler() {
+        this.$store.commit('accounts/SAVE_GOOGLE_ACCOUNT_CONNECTED_ONCE', false);
+        this.$store.commit('accounts/SAVE_MCA_CONNECTED_ONCE', false);
+        this.$store.commit('productFeed/SAVE_CONFIGURATION_CONNECTED_ONCE', false);
+        this.$store.commit('freeListing/SAVE_ACTIVATED_ONCE', false);
+        this.$store.commit('googleAds/SAVE_GOOGLE_ADS_ACCOUNT_CONNECTED_ONCE', false);
+      },
+      deep: true,
+      immediate: true,
+    },
+  },
 };
 </script>


### PR DESCRIPTION
Add watcher on all tabs to automatically close toasts otherwise they display in "configure" each time we come back if we didn't wait enough for the toast to close at first display

Add new route to display list of campaigns 