### PR TITLE
Fix : order of route call & getter remarketing tag

### DIFF
--- a/_dev/src/components/smart-shopping-campaigns/ssc-popin-activate-tracking.vue
+++ b/_dev/src/components/smart-shopping-campaigns/ssc-popin-activate-tracking.vue
@@ -91,12 +91,14 @@ export default {
   },
   data() {
     return {
-      statusTrackingTag: this.$store.getters['smartShoppingCampaigns/GET_REMARKETING_TRACKING_TAG_IS_SET'],
       isLoading: false,
       requestNewConversionTrackingTags: true,
     };
   },
   computed: {
+    statusTrackingTag() {
+      return this.$store.getters['smartShoppingCampaigns/GET_REMARKETING_TRACKING_TAG_IS_SET'];
+    },
     tagAlreadyExists() {
       return this.$store.state.smartShoppingCampaigns.tagAlreadyExists;
     },

--- a/_dev/src/views/onboarding-page.vue
+++ b/_dev/src/views/onboarding-page.vue
@@ -313,15 +313,19 @@ export default {
         this.$store.dispatch('productFeed/GET_PRODUCT_FEED_SETTINGS');
         this.$store.dispatch('productFeed/GET_PRODUCT_FEED_SYNC_STATUS');
         this.$store.dispatch('googleAds/GET_GOOGLE_ADS_LIST');
-        this.$store.dispatch('googleAds/GET_GOOGLE_ADS_ACCOUNT');
-        this.$store.dispatch('smartShoppingCampaigns/GET_REMARKETING_TRACKING_TAG_STATUS_MODULE');
-        this.$store.dispatch('smartShoppingCampaigns/GET_REMARKETING_CONVERSION_ACTIONS_ASSOCIATED');
-        this.$store.dispatch('smartShoppingCampaigns/GET_SSC_LIST');
       }
     },
     productFeedIsConfigured(newVal, oldVal) {
       if (oldVal === false && newVal === true) {
         this.$store.dispatch('freeListing/GET_FREE_LISTING_STATUS');
+        this.$store.dispatch('googleAds/GET_GOOGLE_ADS_ACCOUNT');
+      }
+    },
+    googleAdsAccountIsChosen(newVal, oldVal) {
+      if (oldVal === null && newVal === true) {
+        this.$store.dispatch('smartShoppingCampaigns/GET_REMARKETING_TRACKING_TAG_STATUS_MODULE');
+        this.$store.dispatch('smartShoppingCampaigns/GET_REMARKETING_CONVERSION_ACTIONS_ASSOCIATED');
+        this.$store.dispatch('smartShoppingCampaigns/GET_SSC_LIST');
       }
     },
 


### PR DESCRIPTION
Now we can get the campaigns + remarketing tag status as soon as the google ads account is linked. 
Before that the route `shopping-campaigns/list` was called too early and returned a 500