### PR TITLE
Add country code to missing countries

### DIFF
--- a/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation.vue
+++ b/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation.vue
@@ -440,7 +440,6 @@ export default {
       }
     },
     productsExist() {
-      console.log(this.$store.getters['productFeed/GET_TOTAL_PRODUCTS']);
       return this.$store.getters['productFeed/GET_TOTAL_PRODUCTS'] >= 1;
     },
   },


### PR DESCRIPTION
Czechia and Ivory Coast had no country code which led to an error when merchant didn't chose a target country for their campaign it automatically chose Ivory Coast instead 