### PR TITLE
Add versions when loading js files to refresh cache

### DIFF
--- a/controllers/admin/AdminPsxMktgWithGoogleModuleController.php
+++ b/controllers/admin/AdminPsxMktgWithGoogleModuleController.php
@@ -79,6 +79,7 @@ class AdminPsxMktgWithGoogleModuleController extends ModuleAdminController
             'pathApp' => $this->module->getPathUri() . 'views/js/app.js',
             'psxMktgWithGoogleControllerLink' => $this->context->link->getAdminLink('AdminAjaxPsxMktgWithGoogle'),
             'chunkVendor' => $this->module->getPathUri() . 'views/js/chunk-vendors.js',
+            'version' => $this->module->version,
         ]);
 
         try {

--- a/views/templates/admin/app.tpl
+++ b/views/templates/admin/app.tpl
@@ -19,11 +19,11 @@
 
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
-<link href="{$pathApp|escape:'htmlall':'UTF-8'}" rel=preload as=script>
+<link href="{$pathApp|escape:'htmlall':'UTF-8'}?version={$version|escape:'htmlall':'UTF-8'}" rel=preload as=script>
 
 <div id="psxMktgWithGoogleApp"></div>
-<script src="{$chunkVendor|escape:'htmlall':'UTF-8'}"></script>
-<script src="{$pathApp|escape:'htmlall':'UTF-8'}"></script>
+<script src="{$chunkVendor|escape:'htmlall':'UTF-8'}?version={$version|escape:'htmlall':'UTF-8'}"></script>
+<script src="{$pathApp|escape:'htmlall':'UTF-8'}?version={$version|escape:'htmlall':'UTF-8'}"></script>
 
 <style>
   /** Hide native multistore module activation panel, because of visual regressions on non-bootstrap content */


### PR DESCRIPTION
Based on https://github.com/PrestaShopCorp/ps_facebook/pull/362, we add the module version in the URL to load JS files, so we are sure to refresh the cache at each module reload