### PR TITLE
Fix: phone code

### DIFF
--- a/_dev/src/components/merchant-center-account/phone-verification/phone-verification-popin.vue
+++ b/_dev/src/components/merchant-center-account/phone-verification/phone-verification-popin.vue
@@ -264,7 +264,7 @@ export default {
   },
   computed: {
     phoneNumberNotValid() {
-      return /^\d+$/.test(this.phoneNumber) ? null : true;
+      return !(/^\d+$/.test(this.phoneNumber));
     },
     obfuscatedPhoneNumber() {
       return this.phoneNumber.length > 2


### PR DESCRIPTION
## Fixes: 
- Phone code was sent as phone prefix `+xxx` instead of country code `GB`.
- Check if phone number isn't empty and is digit