### PR TITLE
Call check of existing remarketing tag only when the tag setup modal is opened

### DIFF
--- a/_dev/src/components/smart-shopping-campaigns/ssc-popin-activate-tracking.vue
+++ b/_dev/src/components/smart-shopping-campaigns/ssc-popin-activate-tracking.vue
@@ -5,6 +5,8 @@
     :title="$t('modal.titleActivateTrackingSSC')"
     v-bind="$attrs"
     @ok="updateTrackingStatus"
+    @show="onShow"
+    :ok-disabled="isLoading"
   >
     <VueShowdown
       class="mt-1 mb-4"
@@ -73,7 +75,9 @@
     >
       {{ $t("cta.cancel") }}
     </template>
-    <template slot="modal-ok">
+    <template
+      slot="modal-ok"
+    >
       {{ $t("cta.continue") }}
     </template>
   </ps-modal>
@@ -127,6 +131,19 @@ export default {
       this.$router.push({
         name: 'campaign-creation',
       });
+    },
+    onShow() {
+      this.isLoading = true;
+      this.$store.dispatch('smartShoppingCampaigns/GET_REMARKETING_TRACKING_TAG_STATUS_IF_ALREADY_EXISTS')
+        .then(() => {
+          // Disable the toggle if the tag is found on the shop, so we can display the alert
+          if (this.tagAlreadyExists) {
+            this.statusTrackingTag = false;
+          }
+        })
+        .finally(() => {
+          this.isLoading = false;
+        });
     },
   },
   googleUrl,

--- a/_dev/src/store/modules/smart-shopping-campaigns/actions.ts
+++ b/_dev/src/store/modules/smart-shopping-campaigns/actions.ts
@@ -116,7 +116,6 @@ export default {
     }
     const result = await response.json();
     commit(MutationsTypes.TOGGLE_STATUS_REMARKETING_TRACKING_TAG, result.remarketingTagsStatus);
-    dispatch(ActionsTypes.GET_REMARKETING_TRACKING_TAG_STATUS_IF_ALREADY_EXISTS);
   },
 
   async [ActionsTypes.GET_REMARKETING_TRACKING_TAG_STATUS_IF_ALREADY_EXISTS](

--- a/_dev/stories/smart-shopping-campaigns-popin-tracking.stories.ts
+++ b/_dev/stories/smart-shopping-campaigns-popin-tracking.stories.ts
@@ -26,6 +26,9 @@ Loading.args = {
   visible: true,
   mounted(this: any) {
     this.$refs.SSCPopinActivateTracking.$data.isLoading = true;
+    setTimeout(() => {
+      this.$refs.SSCPopinActivateTracking.$data.isLoading = true;
+    }, 500);
   },
   beforeMount(this: any) {
     this.$store.state.smartShoppingCampaigns = Object.assign({}, sscTrackingIsTrue);


### PR DESCRIPTION
Move an ajax call to the shop at a moment where we need it.

Before this PR, we were checking a AdWords tag exists on the page everytime we opened the Configuration tab. Now the call is done when we open the modal, and displaying the "loading" screen is necessary.