### PR TITLE
Fix: Adds fake psxMktgWithGoogleCarriersUrl in state app mock

### DIFF
--- a/_dev/.storybook/mock/state-app.js
+++ b/_dev/.storybook/mock/state-app.js
@@ -1,27 +1,28 @@
 export const initialStateApp = {
-    psxMktgWithGoogleApiUrl: '',
-    psxMktgWithGoogleShopUrl: 'https://my-shop.com',
-    psxMktgWithGoogleAdminUrl: 'https://my-shop.com/admin-dev',
-    psxMktgWithGoogleAdminAjaxUrl: '/',
-    shopIdPsAccounts: '',
-    tokenPsAccounts: '',
-    psxMtgWithGoogleDefaultShopCountry: null,
-    isCountryMemberOfEuropeanUnion: false,
-    targetCountries: ['FR'],
-    psxMktgWithGoogleShopCurrency: {
-      isoCode: 'EUR',
-    },
-    psxMktgWithGoogleDocumentAndFaq: {
-      faq: {},
-      doc: '',
-      contactUs: '',
-    },
-    psVersion: '',
-    psxMktgWithGoogleModuleVersion: '',
-    psxMktgWithGoogleMaintenanceSettingsUrl: '',
-    psxMktgWithGoogleStoreSettingsUrl: '',
-    shopIsOnMaintenanceMode: false,
-    psxMktgWithGoogleProductDetailUrl: 'https://my-shop.com/admin-dev/index.php/sell/catalog/products/1?token=blabla'
+  psxMktgWithGoogleApiUrl: '',
+  psxMktgWithGoogleShopUrl: 'https://my-shop.com',
+  psxMktgWithGoogleAdminUrl: 'https://my-shop.com/admin-dev',
+  psxMktgWithGoogleAdminAjaxUrl: '/',
+  shopIdPsAccounts: '',
+  tokenPsAccounts: '',
+  psxMtgWithGoogleDefaultShopCountry: null,
+  isCountryMemberOfEuropeanUnion: false,
+  targetCountries: ['FR'],
+  psxMktgWithGoogleShopCurrency: {
+    isoCode: 'EUR',
+  },
+  psxMktgWithGoogleDocumentAndFaq: {
+    faq: {},
+    doc: '',
+    contactUs: '',
+  },
+  psVersion: '',
+  psxMktgWithGoogleModuleVersion: '',
+  psxMktgWithGoogleMaintenanceSettingsUrl: '',
+  psxMktgWithGoogleStoreSettingsUrl: '',
+  shopIsOnMaintenanceMode: false,
+  psxMktgWithGoogleProductDetailUrl: 'https://my-shop.com/admin-dev/index.php/sell/catalog/products/1?token=blabla',
+  psxMktgWithGoogleCarriersUrl: '/',
 };
 
 export const stateWithMaintenanceModeOn = {


### PR DESCRIPTION
To check without whitespace: 
https://github.com/PrestaShopCorp/psxmarketingwithgoogle/pull/663/files?diff=split&w=1