### PR TITLE
Fix reactiveness on delivery detail > delivery type when carrier is configured for the first time

### DIFF
--- a/_dev/src/store/modules/product-feed/actions.ts
+++ b/_dev/src/store/modules/product-feed/actions.ts
@@ -205,7 +205,10 @@ export default {
         (deliveryDetail: DeliveryDetail) => deliveryDetail.carrierId === enabledCarrier.carrierId
         && enabledCarrier.country === deliveryDetail.country);
       if (!additionalShippingSetting) {
-        return enabledCarrier;
+        return {
+          deliveryType: undefined,
+          ...enabledCarrier,
+        };
       }
       return {
         enabledCarrier: true,


### PR DESCRIPTION
We need to set the property, even if it remains undefined, so VueJS can watch its changes