### PR TITLE
Add unit tests about the Continue button in the shipping details

### DIFF
--- a/_dev/src/components/product-feed/settings/shipping-settings/shipping-settings.spec.ts
+++ b/_dev/src/components/product-feed/settings/shipping-settings/shipping-settings.spec.ts
@@ -41,7 +41,7 @@ describe('shipping-settings.vue', () => {
     expect(wrapper.find('#table-carriers').isVisible()).toBe(true);
   });
 
-  it.skip('shows a default message when there are no carriers', () => {
+  it('shows a default message when there are no carriers', () => {
     store.modules.app.state.targetCountries = ['XXX'];
 
     const wrapper = shallowMount(ShippingSettings, {
@@ -53,8 +53,7 @@ describe('shipping-settings.vue', () => {
     });
 
     expect(wrapper.findAllComponents(TableRowCarrier)).toHaveLength(0);
-
-    // TODO: Check the default message is shown
+    expect(wrapper.find('[data-test-id="no-carriers"]').isVisible()).toBe(true);
   });
 
   it('shows the table with carriers filtered by target countries (FR)', () => {


### PR DESCRIPTION
This PR also fixes an issue, where a test was able to alter the data of other tests

All tests running:
![image](https://user-images.githubusercontent.com/6768917/141814762-4685414c-907b-4dd3-9a5a-577e61808710.png)

But running only the test pass:
![image](https://user-images.githubusercontent.com/6768917/141814909-16e693d5-c440-4030-a114-22b252b4051f.png)
