### PR TITLE
Adds few tests for attribute mapping component

### DIFF
--- a/_dev/src/components/product-feed/settings/attribute-mapping/attribute-mapping.spec.ts
+++ b/_dev/src/components/product-feed/settings/attribute-mapping/attribute-mapping.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+import Vuex from 'vuex';
+import {shallowMount} from '@vue/test-utils';
+import {BFormCheckboxGroup, BFormCheckbox} from 'bootstrap-vue';
+import config, {localVue, cloneStore} from '@/../tests/init';
+import AttributeMapping from '@/components/product-feed/settings/attribute-mapping/attribute-mapping.vue';
+import CategoryButton from '@/components/product-feed/settings/attribute-mapping/category-button.vue';
+import ActionsButtons from '@/components/product-feed/settings/commons/actions-buttons.vue';
+
+describe('attribute-mapping.vue', () => {
+  const VBTooltip = jest.fn();
+  const wrapperOptions = {
+    stubs: {
+      ActionsButtons,
+      CategoryButton,
+      BFormCheckboxGroup,
+      BFormCheckbox,
+    },
+    propsData: {
+    },
+    computed: {
+    },
+  };
+
+  let actions;
+  let store;
+  beforeEach(() => {
+    actions = {
+      REQUEST_ATTRIBUTE_MAPPING: jest.fn(),
+      REQUEST_SHOP_TO_GET_ATTRIBUTE: jest.fn(),
+    };
+    store = cloneStore();
+    store.modules.productFeed.actions = {
+      ...store.modules.productFeed.actions,
+      ...actions,
+    };
+  });
+
+  it('is visible', () => {
+    const wrapper = shallowMount(AttributeMapping, {
+      ...wrapperOptions,
+      ...config,
+      store: new Vuex.Store(store),
+    });
+
+    expect(wrapper.isVisible()).toBe(true);
+  });
+
+  it('hides attribute mapping section when no category are selected', async () => {
+    const wrapper = shallowMount(AttributeMapping, {
+      ...wrapperOptions,
+      ...config,
+      store: new Vuex.Store(store),
+    });
+
+    await wrapper.setData({categoryProductsSelected: []});
+    expect(wrapper.find('[data-test-id="section-attribute-field"]').exists()).toBeFalsy();
+  });
+
+  it('displays attribute mapping section when at least one category is selected', async () => {
+    const wrapper = shallowMount(AttributeMapping, {
+      ...wrapperOptions,
+      ...config,
+      store: new Vuex.Store(store),
+    });
+
+    await wrapper.setData({categoryProductsSelected: ['none']});
+    expect(wrapper.find('[data-test-id="section-attribute-field"]').exists()).toBeTruthy();
+  });
+
+  it('disables the button "Continue" if no category are selected', async () => {
+    const wrapper = shallowMount(AttributeMapping, {
+      ...wrapperOptions,
+      ...config,
+      store: new Vuex.Store(store),
+    });
+
+    await wrapper.setData({categoryProductsSelected: []});
+    expect(wrapper.find('[data-test-id="continueButton"]').attributes('disabled')).toBeTruthy();
+  });
+
+  it('allows to "Continue" if at least one category is selected', async () => {
+    const wrapper = shallowMount(AttributeMapping, {
+      ...wrapperOptions,
+      ...config,
+      store: new Vuex.Store(store),
+    });
+
+    await wrapper.setData({categoryProductsSelected: ['none']});
+    expect(wrapper.find('[data-test-id="continueButton"]').attributes('disabled')).toBeFalsy();
+  });
+
+  test.todo('checking any category unchecks "none" category');
+});

--- a/_dev/src/components/product-feed/settings/attribute-mapping/attribute-mapping.vue
+++ b/_dev/src/components/product-feed/settings/attribute-mapping/attribute-mapping.vue
@@ -28,6 +28,7 @@
       <section
         class="mb-2"
         v-if="mappingSectionVisible"
+        data-test-id="section-attribute-field"
       >
         <h3
           class="ps_gs-fz-20 font-weight-600 mb-2"


### PR DESCRIPTION
  attribute-mapping.vue
    ✓ is visible (66ms)
    ✓ hides attribute mapping section when no category are selected (49ms)
    ✓ displays attribute mapping section when at least one category is selected (39ms)
    ✓ disables the button "Continue" if no category are selected (39ms)
    ✓ allows to "Continue" if at least one category is selected (35ms)
    ✎ todo checking any category unchecks "none" category