### PR TITLE
Fix: filters on SSC : add uppercase on condition

### DIFF
--- a/_dev/src/utils/SSCFilters.ts
+++ b/_dev/src/utils/SSCFilters.ts
@@ -88,7 +88,7 @@ export function getFiltersbyIds(productFilters: Array<FiltersChosen>,
   if (availableFilters.children) {
     availableFilters.children.forEach((availableFilter) => {
       const productFilter = productFilters
-        .find((pro) => pro.dimension === availableFilter.name);
+        .find((pro) => pro.dimension?.toUpperCase() === availableFilter.name?.toUpperCase());
       if (availableFilter.children) {
         availableFilter.children.map((child) => {
           if (child.id && productFilter?.values.includes(child.id)) {


### PR DESCRIPTION
Filters list from BO got name "categories" and filters list in SSC got name "Categories" so we check uppercase condition to make sure the === is right