### PR TITLE
Resolve problem on carriers when external_module_name is null

### DIFF
--- a/classes/Builder/CarrierBuilder.php
+++ b/classes/Builder/CarrierBuilder.php
@@ -79,10 +79,8 @@ class CarrierBuilder
     {
         $carrierLines = [];
         foreach ($carriers as $carrier) {
-            $newCarrier = new Carrier($carrier['id_carrier'], $lang->id);
-            $newCarrier->external_module_name = $newCarrier->external_module_name ?? '';
             $carrierLines[] = self::buildCarrier(
-                $newCarrier,
+                new Carrier($carrier['id_carrier'], $lang->id),
                 $currency->iso_code,
                 $weightUnit
             );
@@ -125,7 +123,7 @@ class CarrierBuilder
             ->setIsFree($carrier->is_free)
             ->setShippingExternal($carrier->shipping_external)
             ->setNeedRange($carrier->need_range)
-            ->setExternalModuleName($carrier->external_module_name)
+            ->setExternalModuleName((string) $carrier->external_module_name)
             ->setMaxWidth($carrier->max_width)
             ->setMaxHeight($carrier->max_height)
             ->setMaxDepth($carrier->max_depth)


### PR DESCRIPTION
Link Sentry error : https://sentry.io/organizations/prestashop/issues/2799156976/?project=5949536&query=is%3Aunresolved