### PR TITLE
Test/ga chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -17,7 +17,7 @@ jobs:
   chromatic-deployment:
     # Operating System
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'waiting for UX')
+    if: github.event_name == 'push' || (contains(github.event.pull_request.labels.*.name, 'waiting for UX') && ${{ github.event.pull_request.head.repo.full_name == 'PrestaShopCorp/psxmarketingwithgoogle' }})
     # Job steps
     steps:
         # 👇 Version 2 of the action

--- a/_dev/src/App.vue
+++ b/_dev/src/App.vue
@@ -16,8 +16,8 @@
     <template v-else>
       <div class="ps_gs-sticky-head">
         <Menu>
-        <!-- eslint-disable-next-line -->
-        <!-- We display the tab if user has remarketing tag in the module OR already set elsewhere -->
+          <!-- eslint-disable-next-line -->
+          <!-- We display the tab if user has remarketing tag in the module OR already set elsewhere -->
           <template v-if="reportingTabVisible">
             <MenuItem
               @click.native="throwSegmentEvent"

--- a/_dev/src/App.vue
+++ b/_dev/src/App.vue
@@ -16,8 +16,8 @@
     <template v-else>
       <div class="ps_gs-sticky-head">
         <Menu>
-          <!-- eslint-disable-next-line -->
-          <!-- We display the tab if user has remarketing tag in the module OR already set elsewhere -->
+        <!-- eslint-disable-next-line -->
+        <!-- We display the tab if user has remarketing tag in the module OR already set elsewhere -->
           <template v-if="reportingTabVisible">
             <MenuItem
               @click.native="throwSegmentEvent"


### PR DESCRIPTION
With the change on the chromatic github action:
```
    if: github.event_name == 'push' || (contains(github.event.pull_request.labels.*.name, 'waiting for UX') && ${{ github.event.pull_request.head.repo.full_name == 'PrestaShopCorp/psxmarketingwithgoogle' }})
```
We can now trigger the chromatic build when we add the label `waiting for UX` if the branch is not from a fork.

The chromatic error in the CI is not related to the github action but o an error on 2 of our stories, they should be fixed in a different PR.