### PR TITLE
Fix build of storybook with Typescript in components

### DIFF
--- a/_dev/.storybook/webpack.config.js
+++ b/_dev/.storybook/webpack.config.js
@@ -28,5 +28,19 @@ module.exports = ({ config }) => {
 
     config.resolve.extensions.push(".ts", ".tsx");
 
+    config.module.rules.push({
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'ts-loader',
+            options: {
+              appendTsSuffixTo: [/\.vue$/],
+              transpileOnly: true
+            },
+          }
+        ],
+    });
+
     return config;
 };


### PR DESCRIPTION
Build of storybook is currently broken because it does not recognize the typescript we recently integrated in one component. This PR adds ts-loader.