### PR TITLE
Do not wait for campaign filters to load before displaying ssc list

### DIFF
--- a/_dev/src/views/campaign-page.vue
+++ b/_dev/src/views/campaign-page.vue
@@ -91,7 +91,7 @@ export default {
       await this.$store.dispatch('smartShoppingCampaigns/GET_SSC_LIST');
       await this.$store.dispatch('smartShoppingCampaigns/GET_REMARKETING_TRACKING_TAG_STATUS_MODULE');
       await this.$store.dispatch('smartShoppingCampaigns/GET_REMARKETING_CONVERSION_ACTIONS_ASSOCIATED');
-      await this.$store.dispatch('smartShoppingCampaigns/GET_DIMENSIONS_FILTERS', null);
+      this.$store.dispatch('smartShoppingCampaigns/GET_DIMENSIONS_FILTERS', null);
     },
     onOpenPopinActivateTracking() {
       this.$bvModal.show(


### PR DESCRIPTION
Loading the SSC list takes too much time. This first PR is a quick win to remove a few seconds of loading time.