### PR TITLE
Refacto vue router

### DIFF
--- a/_dev/jest.config.js
+++ b/_dev/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    "^@enums/(.*)": "<rootDir>/src/enums/$1"
   },
   snapshotSerializers: [
     'jest-serializer-vue',

--- a/_dev/jest.config.js
+++ b/_dev/jest.config.js
@@ -16,7 +16,7 @@ module.exports = {
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-    "^@enums/(.*)": "<rootDir>/src/enums/$1"
+    '^@enums/(.*)': '<rootDir>/src/enums/$1',
   },
   snapshotSerializers: [
     'jest-serializer-vue',

--- a/_dev/jest.config.js
+++ b/_dev/jest.config.js
@@ -16,7 +16,6 @@ module.exports = {
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-    '^@enums/(.*)': '<rootDir>/src/enums/$1',
   },
   snapshotSerializers: [
     'jest-serializer-vue',

--- a/_dev/src/App.vue
+++ b/_dev/src/App.vue
@@ -30,7 +30,7 @@
             {{ $t('general.tabs.exportStatus') }}
           </MenuItem>
           <MenuItem
-            :route="{name: 'campaign'}"
+            :route="{name: 'campaign-info'}"
           >
             {{ $t('general.tabs.campaign') }}
           </MenuItem>

--- a/_dev/src/App.vue
+++ b/_dev/src/App.vue
@@ -30,7 +30,7 @@
             {{ $t('general.tabs.exportStatus') }}
           </MenuItem>
           <MenuItem
-            :route="{name: 'campaign-info'}"
+            :route="{name: 'campaign'}"
           >
             {{ $t('general.tabs.campaign') }}
           </MenuItem>

--- a/_dev/src/App.vue
+++ b/_dev/src/App.vue
@@ -17,28 +17,23 @@
       <div class="ps_gs-sticky-head">
         <Menu>
           <!-- eslint-disable-next-line -->
-          <!-- We display the tab if user has remarketing tag in the module OR already set elsewhere -->
-          <template v-if="reportingTabVisible">
             <MenuItem
-              @click.native="throwSegmentEvent"
-              :route="{name: 'reporting'}"
-            >
-              {{ $t('general.tabs.reporting') }}
-            </MenuItem>
-          </template>
-          <template v-if="productFeedIsConfigured">
-            <MenuItem
-              :route="{name: 'product-feed'}"
-            >
-              {{ $t('general.tabs.exportStatus') }}
-            </MenuItem>
-            <MenuItem
-              v-if="googleAdsServing"
-              :route="{name: 'campaign'}"
-            >
-              {{ $t('general.tabs.campaign') }}
-            </MenuItem>
-          </template>
+            @click.native="throwSegmentEvent"
+            :route="{name: 'reporting'}"
+          >
+            {{ $t('general.tabs.reporting') }}
+          </MenuItem>
+
+          <MenuItem
+            :route="{name: 'product-feed'}"
+          >
+            {{ $t('general.tabs.exportStatus') }}
+          </MenuItem>
+          <MenuItem
+            :route="{name: 'campaign'}"
+          >
+            {{ $t('general.tabs.campaign') }}
+          </MenuItem>
           <MenuItem
             :route="{name: 'configuration'}"
           >
@@ -94,18 +89,7 @@ export default {
   },
 
   computed: {
-    productFeedIsConfigured() {
-      return this.$store.getters['productFeed/GET_PRODUCT_FEED_IS_CONFIGURED'];
-    },
-    googleAdsServing() {
-      return this.$store.getters['googleAds/GET_GOOGLE_ADS_ACCOUNT_IS_SERVING'];
-    },
-    remarketingTag() {
-      return this.$store.getters['smartShoppingCampaigns/GET_REMARKETING_TRACKING_TAG_STATUS'];
-    },
-    reportingTabVisible() {
-      return this.$store.getters['smartShoppingCampaigns/GET_REPORTING_TAB_IS_ACTIVE'];
-    },
+
     shopId() {
       return window.shopIdPsAccounts;
     },

--- a/_dev/src/components/commons/stepper.spec.ts
+++ b/_dev/src/components/commons/stepper.spec.ts
@@ -6,18 +6,21 @@ import Vuex from 'vuex';
 // Import this file first to init mock on window
 import {shallowMount} from '@vue/test-utils';
 import config, {cloneStore} from '@/../tests/init';
-
 import Stepper from '@/components/commons/stepper.vue';
 import {state} from '../../store/modules/product-feed/state';
 
 describe('stepper.vue', () => {
   const productFeedSettingsRoute = {
     name: 'product-feed-settings',
+    params: {
+      step: "target-country"
+    }
   };
-  const fooRoute = {
+ 
+  const routeName = {
     name: 'foo',
   };
-
+const push = jest.fn();
   const mockRouter = {
     push: jest.fn(),
   };
@@ -26,6 +29,9 @@ describe('stepper.vue', () => {
     activeStep: 3,
     steps: [
       {
+        title: 'Target Country',
+      },
+      {
         title: 'Shipping settings',
       },
       {
@@ -33,6 +39,9 @@ describe('stepper.vue', () => {
       },
       {
         title: 'Attribute mapping',
+      },
+      {
+        title: 'Sync schedule',
       },
       {
         title: 'Summary',
@@ -100,12 +109,13 @@ describe('stepper.vue', () => {
     // Check if the mutation SET_ACTIVE_CONFIGURATION_STEP has been called
     await wrapper.findAll('a').at(0).trigger('click');
     expect(mutations.SET_ACTIVE_CONFIGURATION_STEP).toHaveBeenCalledWith(state, 1);
+
   });
 
   it('test event emited when we click on a previous step on any other page', async () => {
     const wrapper = shallowMount(Stepper, {
       mocks: {
-        $route: fooRoute,
+        $route: routeName,
         $router: mockRouter,
       },
       propsData,

--- a/_dev/src/components/commons/stepper.spec.ts
+++ b/_dev/src/components/commons/stepper.spec.ts
@@ -13,14 +13,14 @@ describe('stepper.vue', () => {
   const productFeedSettingsRoute = {
     name: 'product-feed-settings',
     params: {
-      step: "target-country"
-    }
+      step: 'target-country',
+    },
   };
- 
+
   const routeName = {
     name: 'foo',
   };
-const push = jest.fn();
+  const push = jest.fn();
   const mockRouter = {
     push: jest.fn(),
   };
@@ -109,7 +109,6 @@ const push = jest.fn();
     // Check if the mutation SET_ACTIVE_CONFIGURATION_STEP has been called
     await wrapper.findAll('a').at(0).trigger('click');
     expect(mutations.SET_ACTIVE_CONFIGURATION_STEP).toHaveBeenCalledWith(state, 1);
-
   });
 
   it('test event emited when we click on a previous step on any other page', async () => {

--- a/_dev/src/components/commons/stepper.vue
+++ b/_dev/src/components/commons/stepper.vue
@@ -57,7 +57,7 @@ import {
   BIconCheck,
   BIconSlash,
 } from 'bootstrap-vue';
-import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
 import ProgressRing from '../commons/progress-ring';
 
 export default {

--- a/_dev/src/components/commons/stepper.vue
+++ b/_dev/src/components/commons/stepper.vue
@@ -57,7 +57,7 @@ import {
   BIconCheck,
   BIconSlash,
 } from 'bootstrap-vue';
-
+import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
 import ProgressRing from '../commons/progress-ring';
 
 export default {
@@ -114,6 +114,21 @@ export default {
         if (this.mutableActiveStep >= value) {
           if (this.$route.name === 'product-feed-settings') {
             this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', value);
+            this.$router.push({
+              name: 'product-feed-settings',
+              params: {
+                /* eslint-disable no-nested-ternary */
+
+                step: value === 1 ? ProductFeedSettingsPages.TARGET_COUNTRY
+                  : value === 2 ? ProductFeedSettingsPages.SHIPPING_SETTINGS
+                    : value === 3 ? ProductFeedSettingsPages.ATTRIBUTE_MAPPING
+                      : value === 4 ? ProductFeedSettingsPages.SYNC_SCHEDULE
+                        : value === 5 ? ProductFeedSettingsPages.SUMMARY
+                          : null,
+                /* eslint-enable no-nested-ternary */
+
+              },
+            });
           } else {
             this.$emit('changeStep', value);
           }

--- a/_dev/src/components/commons/stepper.vue
+++ b/_dev/src/components/commons/stepper.vue
@@ -117,14 +117,14 @@ export default {
             this.$router.push({
               name: 'product-feed-settings',
               params: {
-                /* eslint-disable no-nested-ternary */
-
-                step: value === 1 ? ProductFeedSettingsPages.TARGET_COUNTRY
-                  : value === 2 ? ProductFeedSettingsPages.SHIPPING_SETTINGS
-                    : value === 3 ? ProductFeedSettingsPages.ATTRIBUTE_MAPPING
-                      : value === 4 ? ProductFeedSettingsPages.SYNC_SCHEDULE
-                        : value === 5 ? ProductFeedSettingsPages.SUMMARY
-                          : null,
+                step: [
+                  null,
+                  ProductFeedSettingsPages.TARGET_COUNTRY,
+                  ProductFeedSettingsPages.SHIPPING_SETTINGS,
+                  ProductFeedSettingsPages.ATTRIBUTE_MAPPING,
+                  ProductFeedSettingsPages.SYNC_SCHEDULE,
+                  ProductFeedSettingsPages.SUMMARY,
+                ][value] || null,
                 /* eslint-enable no-nested-ternary */
 
               },

--- a/_dev/src/components/commons/stepper.vue
+++ b/_dev/src/components/commons/stepper.vue
@@ -57,7 +57,7 @@ import {
   BIconCheck,
   BIconSlash,
 } from 'bootstrap-vue';
-import ProductFeedSettingsSteps from '@/enums/product-feed/product-feed-settings-pages';
+import ProductFeedSettingsSteps from '@/enums/product-feed/product-feed-settings-steps';
 import ProgressRing from '../commons/progress-ring';
 
 export default {

--- a/_dev/src/components/commons/stepper.vue
+++ b/_dev/src/components/commons/stepper.vue
@@ -57,7 +57,7 @@ import {
   BIconCheck,
   BIconSlash,
 } from 'bootstrap-vue';
-import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
+import ProductFeedSettingsSteps from '@/enums/product-feed/product-feed-settings-pages';
 import ProgressRing from '../commons/progress-ring';
 
 export default {
@@ -117,14 +117,7 @@ export default {
             this.$router.push({
               name: 'product-feed-settings',
               params: {
-                step: [
-                  null,
-                  ProductFeedSettingsPages.TARGET_COUNTRY,
-                  ProductFeedSettingsPages.SHIPPING_SETTINGS,
-                  ProductFeedSettingsPages.ATTRIBUTE_MAPPING,
-                  ProductFeedSettingsPages.SYNC_SCHEDULE,
-                  ProductFeedSettingsPages.SUMMARY,
-                ][value] || null,
+                step: ProductFeedSettingsSteps[value] || null,
 
               },
             });

--- a/_dev/src/components/commons/stepper.vue
+++ b/_dev/src/components/commons/stepper.vue
@@ -125,7 +125,6 @@ export default {
                   ProductFeedSettingsPages.SYNC_SCHEDULE,
                   ProductFeedSettingsPages.SUMMARY,
                 ][value] || null,
-                /* eslint-enable no-nested-ternary */
 
               },
             });

--- a/_dev/src/components/landing-page/landing-page-footer.spec.ts
+++ b/_dev/src/components/landing-page/landing-page-footer.spec.ts
@@ -7,19 +7,20 @@ import {shallowMount} from '@vue/test-utils';
 import config from '@/../tests/init';
 
 import LandingPageFooter from '@/components/landing-page/landing-page-footer.vue';
+
 describe('landing-page-footer.vue', () => {
   const $route = {
-    name: "configuration"
-  }
+    name: 'configuration',
+  };
   it('Emit event to route push when click on CTA', async () => {
     const wrapper = shallowMount(LandingPageFooter, {
       ...config,
       mocks: {
-        $route
-      } 
+        $route,
+      },
     });
     await wrapper.find('[data-test-id="lp-footer-cta"]').trigger('click');
-    expect(wrapper.vm.$route.name).toBe($route.name)
+    expect(wrapper.vm.$route.name).toBe($route.name);
     expect(wrapper.emitted('hideLandingPage')).toBeTruthy();
   });
 });

--- a/_dev/src/components/landing-page/landing-page-footer.spec.ts
+++ b/_dev/src/components/landing-page/landing-page-footer.spec.ts
@@ -3,21 +3,23 @@
  */
 
 // Import this file first to init mock on window
-import {createWrapper, shallowMount} from '@vue/test-utils';
+import {shallowMount} from '@vue/test-utils';
 import config from '@/../tests/init';
 
 import LandingPageFooter from '@/components/landing-page/landing-page-footer.vue';
-
 describe('landing-page-footer.vue', () => {
-  it('Emit event to hide landing page when click on CTA', async () => {
+  const $route = {
+    name: "configuration"
+  }
+  it('Emit event to route push when click on CTA', async () => {
     const wrapper = shallowMount(LandingPageFooter, {
       ...config,
+      mocks: {
+        $route
+      } 
     });
-
-    // Check if onHideLanding event has been emmited when btn is clicked
     await wrapper.find('[data-test-id="lp-footer-cta"]').trigger('click');
-    const rootWrapper = createWrapper(wrapper.vm.$root);
-
-    expect(rootWrapper.emitted('onHideLanding')).toBeTruthy();
+    expect(wrapper.vm.$route.name).toBe($route.name)
+    expect(wrapper.emitted('hideLandingPage')).toBeTruthy();
   });
 });

--- a/_dev/src/components/landing-page/landing-page-footer.vue
+++ b/_dev/src/components/landing-page/landing-page-footer.vue
@@ -3,15 +3,15 @@
     <b-row class="flex-column flex-sm-row">
       <b-col>
         <p class="ps_gs-landingpage-footer__text mb-3">
-          {{ $t('landingPage.footer.text') }}
+          {{ $t("landingPage.footer.text") }}
         </p>
         <b-button
           size="sm"
           variant="primary"
-          @click="hideLandingPage"
+          @click="$emit('hideLandingPage')"
           data-test-id="lp-footer-cta"
         >
-          {{ $t('cta.startConfiguring') }}
+          {{ $t("cta.startConfiguring") }}
         </b-button>
       </b-col>
     </b-row>
@@ -19,22 +19,8 @@
 </template>
 
 <script>
-import SegmentGenericParams from '@/utils/SegmentGenericParams';
 
 export default {
   name: 'LandingPageFooter',
-  data() {
-    return {
-    };
-  },
-  methods: {
-    hideLandingPage() {
-      this.$root.$emit('onHideLanding');
-      this.$segment.track('[GGL] Start Configuration', {
-        module: 'psxmarketingwithgoogle',
-        params: SegmentGenericParams,
-      });
-    },
-  },
 };
 </script>

--- a/_dev/src/components/landing-page/landing-page-header.spec.ts
+++ b/_dev/src/components/landing-page/landing-page-header.spec.ts
@@ -3,21 +3,25 @@
  */
 
 // Import this file first to init mock on window
-import {createWrapper, shallowMount} from '@vue/test-utils';
+import {shallowMount} from '@vue/test-utils';
 import config from '@/../tests/init';
 
 import LandingPageHeader from '@/components/landing-page/landing-page-header.vue';
 
 describe('landing-page-header.vue', () => {
-  it('Emit event to hide landing page when click on CTA', async () => {
+  const $route = {
+    name: "configuration"
+  }
+  it('Emit event to route push when click on CTA', async () => {
     const wrapper = shallowMount(LandingPageHeader, {
       ...config,
+      mocks: {
+        $route
+      } 
     });
 
-    // Check if onHideLanding event has been emmited when btn is clicked
     await wrapper.find('[data-test-id="lp-header-cta"]').trigger('click');
-    const rootWrapper = createWrapper(wrapper.vm.$root);
-
-    expect(rootWrapper.emitted('onHideLanding')).toBeTruthy();
+     expect(wrapper.vm.$route.name).toBe($route.name)
+     expect(wrapper.emitted('hideLandingPage')).toBeTruthy();
   });
 });

--- a/_dev/src/components/landing-page/landing-page-header.spec.ts
+++ b/_dev/src/components/landing-page/landing-page-header.spec.ts
@@ -10,18 +10,18 @@ import LandingPageHeader from '@/components/landing-page/landing-page-header.vue
 
 describe('landing-page-header.vue', () => {
   const $route = {
-    name: "configuration"
-  }
+    name: 'configuration',
+  };
   it('Emit event to route push when click on CTA', async () => {
     const wrapper = shallowMount(LandingPageHeader, {
       ...config,
       mocks: {
-        $route
-      } 
+        $route,
+      },
     });
 
     await wrapper.find('[data-test-id="lp-header-cta"]').trigger('click');
-     expect(wrapper.vm.$route.name).toBe($route.name)
-     expect(wrapper.emitted('hideLandingPage')).toBeTruthy();
+    expect(wrapper.vm.$route.name).toBe($route.name);
+    expect(wrapper.emitted('hideLandingPage')).toBeTruthy();
   });
 });

--- a/_dev/src/components/landing-page/landing-page-header.vue
+++ b/_dev/src/components/landing-page/landing-page-header.vue
@@ -29,7 +29,7 @@
         size="sm"
         variant="primary"
         class="my-2"
-        @click="hideLandingPage"
+        @click="$emit('hideLandingPage')"
         data-test-id="lp-header-cta"
       >
         {{ $t('cta.startConfiguring') }}
@@ -46,26 +46,11 @@
 
 <script>
 import {VueShowdown} from 'vue-showdown';
-import SegmentGenericParams from '@/utils/SegmentGenericParams';
 
 export default {
   name: 'LandingPageHeader',
   components: {
     VueShowdown,
-  },
-  data() {
-    return {
-    };
-  },
-  methods: {
-    hideLandingPage() {
-      this.$root.$emit('onHideLanding');
-      localStorage.setItem('canDisplayLanding', false);
-      this.$segment.track('[GGL] Start Configuration', {
-        module: 'psxmarketingwithgoogle',
-        params: SegmentGenericParams,
-      });
-    },
   },
 };
 </script>

--- a/_dev/src/components/product-feed/product-feed-card-report-card.vue
+++ b/_dev/src/components/product-feed/product-feed-card-report-card.vue
@@ -93,19 +93,13 @@ export default {
   },
   methods: {
     goTo(link) {
-      //  Here I added and check a link type because it's not an url or route but a stepper state.
-      //  If one day we need to give a simple url we can add a different type in the condition below
-      if (link.type === 'stepper') {
-        this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', link.name);
-      } else if (link.type === 'routeStep') {
-        this.$router.push({
-          name: link.name,
-          params: {
-            step: link.params,
-          },
-        });
-        this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', link.step);
-      }
+      this.$router.push({
+        name: link.name,
+        params: {
+          step: link.params,
+        },
+      });
+      this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', link.step);
     },
   },
 };

--- a/_dev/src/components/product-feed/product-feed-card-report-card.vue
+++ b/_dev/src/components/product-feed/product-feed-card-report-card.vue
@@ -100,6 +100,9 @@ export default {
       } else if (link.type === 'routeStep') {
         this.$router.push({
           name: link.name,
+          params: {
+            step: link.params,
+          },
         });
         this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', link.step);
       }

--- a/_dev/src/components/product-feed/product-feed-card.spec.ts
+++ b/_dev/src/components/product-feed/product-feed-card.spec.ts
@@ -27,8 +27,8 @@ describe('product-feed-card.vue', () => {
   const mockRoute = {
     name: 'product-feed-settings',
     params: {
-      step: ProductFeedSettingsPages.TARGET_COUNTRY
-    }
+      step: ProductFeedSettingsPages.TARGET_COUNTRY,
+    },
   };
   const mockRouter = {
     push: jest.fn(),

--- a/_dev/src/components/product-feed/product-feed-card.spec.ts
+++ b/_dev/src/components/product-feed/product-feed-card.spec.ts
@@ -12,7 +12,7 @@ import BadgeListRequirements from '@/components/commons/badge-list-requirements.
 import ProductFeedCard from '@/components/product-feed/product-feed-card.vue';
 import ProductFeedCardReportCard from '@/components/product-feed/product-feed-card-report-card.vue';
 import Stepper from '@/components/commons/stepper.vue';
-import ProductFeedSettingsPages from '../../enums/product-feed/product-feed-settings-pages';
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
 
 import {
   productFeed,

--- a/_dev/src/components/product-feed/product-feed-card.spec.ts
+++ b/_dev/src/components/product-feed/product-feed-card.spec.ts
@@ -12,11 +12,12 @@ import BadgeListRequirements from '@/components/commons/badge-list-requirements.
 import ProductFeedCard from '@/components/product-feed/product-feed-card.vue';
 import ProductFeedCardReportCard from '@/components/product-feed/product-feed-card-report-card.vue';
 import Stepper from '@/components/commons/stepper.vue';
+import ProductFeedSettingsPages from '../../enums/product-feed/product-feed-settings-pages';
+
 import {
   productFeed,
   productFeedIsReadyForExport,
   productFeedIsConfigured,
-  productFeedIsConfiguredWithTax,
   productFeedMissingFields,
   productFeedStatusSyncFailed,
   productFeedErrorAPI,
@@ -25,6 +26,9 @@ import {
 describe('product-feed-card.vue', () => {
   const mockRoute = {
     name: 'product-feed-settings',
+    params: {
+      step: ProductFeedSettingsPages.TARGET_COUNTRY
+    }
   };
   const mockRouter = {
     push: jest.fn(),
@@ -121,9 +125,6 @@ describe('product-feed-card.vue', () => {
         isEnabled: true,
       },
       ...config,
-      mocks: {
-        $router: mockRouter,
-      },
       localVue,
       store: new Vuex.Store(storeConfigured),
     });
@@ -141,9 +142,6 @@ describe('product-feed-card.vue', () => {
         isEnabled: true,
       },
       ...config,
-      mocks: {
-        $router: mockRouter,
-      },
       localVue,
       stubs: {
         VueShowdown: true,
@@ -164,9 +162,6 @@ describe('product-feed-card.vue', () => {
         isEnabled: true,
       },
       ...config,
-      mocks: {
-        $router: mockRouter,
-      },
       localVue,
       store: new Vuex.Store(storeMissingFields),
       stubs: {
@@ -211,9 +206,6 @@ describe('product-feed-card.vue', () => {
         isEnabled: true,
       },
       ...config,
-      mocks: {
-        $router: mockRouter,
-      },
       localVue,
       store: new Vuex.Store(storeSyncFailed),
       stubs: {

--- a/_dev/src/components/product-feed/product-feed-card.vue
+++ b/_dev/src/components/product-feed/product-feed-card.vue
@@ -167,7 +167,7 @@
             <div class="mt-1">
               <b-button
                 variant="outline-secondary"
-                @click="goToProductFeedSettings(2, ProductFeedSettingsPages.SHIPPING_SETTINGS)"
+                @click="goToProductFeedSettings(ProductFeedSettingsPages.SHIPPING_SETTINGS)"
               >
                 {{ $t("cta.addShippingInfo") }}
               </b-button>
@@ -474,14 +474,13 @@ export default {
         params: SegmentGenericParams,
       });
     },
-    goToProductFeedSettings(step, params) {
+    goToProductFeedSettings(params) {
       this.$router.push({
         name: 'product-feed-settings',
         params: {
           step: params,
         },
       });
-      this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', step);
     },
     refresh() {
       this.$router.go();

--- a/_dev/src/components/product-feed/product-feed-card.vue
+++ b/_dev/src/components/product-feed/product-feed-card.vue
@@ -224,7 +224,7 @@
 
 <script>
 import {VueShowdown} from 'vue-showdown';
-import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
 import googleUrl from '@/assets/json/googleUrl.json';
 import Stepper from '../commons/stepper';
 import ProductFeedCardReportCard from './product-feed-card-report-card';

--- a/_dev/src/components/product-feed/product-feed-card.vue
+++ b/_dev/src/components/product-feed/product-feed-card.vue
@@ -167,7 +167,7 @@
             <div class="mt-1">
               <b-button
                 variant="outline-secondary"
-                @click="goToProductFeedSettings(1)"
+                @click="goToProductFeedSettings(2, ProductFeedSettingsPages.SHIPPING_SETTINGS)"
               >
                 {{ $t("cta.addShippingInfo") }}
               </b-button>
@@ -186,14 +186,16 @@
                 :title="$t('productFeedSettings.shipping.targetCountries')"
                 :description="targetCountries.join(', ')"
                 :link="$t('cta.editCountries')"
-                :link-to="{ type: 'routeStep', name: 'product-feed-settings', step: 1 }"
+                :link-to="{ type: 'routeStep', name: 'product-feed-settings',
+                            step: 1, params: ProductFeedSettingsPages.TARGET_COUNTRY }"
               />
               <product-feed-card-report-card
                 :status="shippingSettingsStatus"
                 :title="$t('productFeedSettings.shipping.shippingSettings')"
                 :description="shippingSettings"
                 :link="$t('cta.editSettings')"
-                :link-to="{ type: 'routeStep', name: 'product-feed-settings', step: 1 }"
+                :link-to="{ type: 'routeStep', name: 'product-feed-settings',
+                            step: 2, params: ProductFeedSettingsPages.SHIPPING_SETTINGS }"
               />
               <product-feed-card-report-card
                 v-if="isUS"
@@ -201,14 +203,16 @@
                 :title="$t('productFeedSettings.shipping.taxSettings')"
                 :description="taxSettings"
                 :link="$t('cta.editSettings')"
-                :link-to="{ type: 'routeStep', name: 'product-feed-settings', step: 1 }"
+                :link-to="{ type: 'routeStep', name: 'product-feed-settings',
+                            step: 1, params: ProductFeedSettingsPages.TARGET_COUNTRY }"
               />
               <product-feed-card-report-card
                 :status="attributeMappingStatus"
                 :title="$t('productFeedSettings.steps.attributeMapping')"
                 :description="attributeMapping.join(', ')"
                 :link="$t('cta.editProductAttributes')"
-                :link-to="{ type: 'routeStep', name: 'product-feed-settings', step: 3 }"
+                :link-to="{ type: 'routeStep', name: 'product-feed-settings',
+                            step: 3, params: ProductFeedSettingsPages.ATTRIBUTE_MAPPING}"
               />
             </b-row>
           </b-container>
@@ -220,6 +224,7 @@
 
 <script>
 import {VueShowdown} from 'vue-showdown';
+import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
 import googleUrl from '@/assets/json/googleUrl.json';
 import Stepper from '../commons/stepper';
 import ProductFeedCardReportCard from './product-feed-card-report-card';
@@ -459,15 +464,21 @@ export default {
     startConfiguration() {
       this.$router.push({
         name: 'product-feed-settings',
+        params: {
+          step: ProductFeedSettingsPages.TARGET_COUNTRY,
+        },
       });
       this.$segment.track('[GGL] Start Product feed configuration', {
         module: 'psxmarketingwithgoogle',
         params: SegmentGenericParams,
       });
     },
-    goToProductFeedSettings(step) {
+    goToProductFeedSettings(step, params) {
       this.$router.push({
         name: 'product-feed-settings',
+        params: {
+          step: params,
+        },
       });
       this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', step);
     },

--- a/_dev/src/components/product-feed/product-feed-card.vue
+++ b/_dev/src/components/product-feed/product-feed-card.vue
@@ -186,7 +186,7 @@
                 :title="$t('productFeedSettings.shipping.targetCountries')"
                 :description="targetCountries.join(', ')"
                 :link="$t('cta.editCountries')"
-                :link-to="{ type: 'routeStep', name: 'product-feed-settings',
+                :link-to="{ name: 'product-feed-settings',
                             step: 1, params: ProductFeedSettingsPages.TARGET_COUNTRY }"
               />
               <product-feed-card-report-card
@@ -194,7 +194,7 @@
                 :title="$t('productFeedSettings.shipping.shippingSettings')"
                 :description="shippingSettings"
                 :link="$t('cta.editSettings')"
-                :link-to="{ type: 'routeStep', name: 'product-feed-settings',
+                :link-to="{ name: 'product-feed-settings',
                             step: 2, params: ProductFeedSettingsPages.SHIPPING_SETTINGS }"
               />
               <product-feed-card-report-card
@@ -203,7 +203,7 @@
                 :title="$t('productFeedSettings.shipping.taxSettings')"
                 :description="taxSettings"
                 :link="$t('cta.editSettings')"
-                :link-to="{ type: 'routeStep', name: 'product-feed-settings',
+                :link-to="{ name: 'product-feed-settings',
                             step: 1, params: ProductFeedSettingsPages.TARGET_COUNTRY }"
               />
               <product-feed-card-report-card
@@ -211,7 +211,7 @@
                 :title="$t('productFeedSettings.steps.attributeMapping')"
                 :description="attributeMapping.join(', ')"
                 :link="$t('cta.editProductAttributes')"
-                :link-to="{ type: 'routeStep', name: 'product-feed-settings',
+                :link-to="{ name: 'product-feed-settings',
                             step: 3, params: ProductFeedSettingsPages.ATTRIBUTE_MAPPING}"
               />
             </b-row>

--- a/_dev/src/components/product-feed/product-feed-card.vue
+++ b/_dev/src/components/product-feed/product-feed-card.vue
@@ -241,6 +241,7 @@ export default {
   },
   data() {
     return {
+      ProductFeedSettingsPages,
       steps: [
         {
           title: this.$i18n.t('productFeedSettings.steps.targetCountry'),

--- a/_dev/src/components/product-feed/product-feed-popin-cancel.vue
+++ b/_dev/src/components/product-feed/product-feed-popin-cancel.vue
@@ -31,7 +31,7 @@ export default {
     onProductFeedCancelConfirmation() {
       this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', 1);
       this.$router.push({
-        name: 'onboarding',
+        name: 'configuration',
         hash: '#product-feed-card',
       });
     },

--- a/_dev/src/components/product-feed/product-feed-settings.vue
+++ b/_dev/src/components/product-feed/product-feed-settings.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script>
-import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
+import {ProductFeedSettingsSteps} from '@/enums/product-feed/product-feed-settings-pages';
 import Stepper from '../commons/stepper';
 import TargetCountry from './settings/target-countries/target-countries.vue';
 import ShippingSettings from './settings/shipping-settings/shipping-settings.vue';
@@ -85,14 +85,9 @@ export default {
       if (this.$store.state.productFeed.stepper > 0) {
         return this.$store.state.productFeed.stepper;
       }
-      /* eslint-disable no-nested-ternary */
-      return this.$route.path.includes(ProductFeedSettingsPages.TARGET_COUNTRY) ? 1
-        : this.$route.path.includes(ProductFeedSettingsPages.SHIPPING_SETTINGS) ? 2
-          : this.$route.path.includes(ProductFeedSettingsPages.ATTRIBUTE_MAPPING) ? 3
-            : this.$route.path.includes(ProductFeedSettingsPages.SYNC_SCHEDULE) ? 4
-              : this.$route.path.includes(ProductFeedSettingsPages.SUMMARY) ? 5
-                : 1;
-      /* eslint-enable no-nested-ternary  */
+      const stepIs = ProductFeedSettingsSteps.indexOf(this.$route.params.step);
+
+      return stepIs;
     },
     steps() {
       return [
@@ -116,7 +111,6 @@ export default {
     },
   },
   mounted() {
-    console.log(this.$store.state.productFeed.stepper);
     this.$store.dispatch('productFeed/REQUEST_SHOP_TO_GET_ATTRIBUTE');
   },
   methods: {

--- a/_dev/src/components/product-feed/product-feed-settings.vue
+++ b/_dev/src/components/product-feed/product-feed-settings.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script>
-import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
 import Stepper from '../commons/stepper';
 import TargetCountry from './settings/target-countries/target-countries.vue';
 import ShippingSettings from './settings/shipping-settings/shipping-settings.vue';

--- a/_dev/src/components/product-feed/product-feed-settings.vue
+++ b/_dev/src/components/product-feed/product-feed-settings.vue
@@ -36,25 +36,25 @@
         :active-step="activeStep"
       />
       <target-country
-        v-if="activeStep == 1"
+        v-if="$route.params.step === ProductFeedSettingsPages.TARGET_COUNTRY"
         @cancelProductFeedSettingsConfiguration="productFeedCancelProcess"
       />
       <shipping-settings
-        v-if="activeStep == 2"
+        v-if="$route.params.step === ProductFeedSettingsPages.SHIPPING_SETTINGS"
         v-bind="$attrs"
         @cancelProductFeedSettingsConfiguration="productFeedCancelProcess"
       />
       <attribute-mapping
-        v-if="activeStep == 3"
+        v-if="$route.params.step === ProductFeedSettingsPages.ATTRIBUTE_MAPPING"
         @cancelProductFeedSettingsConfiguration="productFeedCancelProcess"
       />
       <sync-schedule
-        v-if="activeStep == 4"
+        v-if="$route.params.step === ProductFeedSettingsPages.SYNC_SCHEDULE"
         @cancelProductFeedSettingsConfiguration="productFeedCancelProcess"
       />
       <Summary
         v-bind="$attrs"
-        v-if="activeStep == 5"
+        v-if="$route.params.step === ProductFeedSettingsPages.SUMMARY"
         @cancelProductFeedSettingsConfiguration="productFeedCancelProcess"
       />
     </b-card-body>
@@ -63,6 +63,7 @@
 
 <script>
 import ProductFeedSettingsSteps from '@/enums/product-feed/product-feed-settings-steps';
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
 import Stepper from '../commons/stepper';
 import TargetCountry from './settings/target-countries/target-countries.vue';
 import ShippingSettings from './settings/shipping-settings/shipping-settings.vue';
@@ -79,6 +80,11 @@ export default {
     AttributeMapping,
     SyncSchedule,
     Summary,
+  },
+  data() {
+    return {
+      ProductFeedSettingsPages,
+    };
   },
   computed: {
     activeStep() {

--- a/_dev/src/components/product-feed/product-feed-settings.vue
+++ b/_dev/src/components/product-feed/product-feed-settings.vue
@@ -50,6 +50,7 @@
       />
       <sync-schedule
         v-if="activeStep == 4"
+        @cancelProductFeedSettingsConfiguration="productFeedCancelProcess"
       />
       <Summary
         v-bind="$attrs"
@@ -61,6 +62,7 @@
 </template>
 
 <script>
+import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
 import Stepper from '../commons/stepper';
 import TargetCountry from './settings/target-countries/target-countries.vue';
 import ShippingSettings from './settings/shipping-settings/shipping-settings.vue';
@@ -78,13 +80,19 @@ export default {
     SyncSchedule,
     Summary,
   },
-  data() {
-    return {
-    };
-  },
   computed: {
     activeStep() {
-      return this.$store.state.productFeed.stepper;
+      if (this.$store.state.productFeed.stepper > 0) {
+        return this.$store.state.productFeed.stepper;
+      }
+      /* eslint-disable no-nested-ternary */
+      return this.$route.path.includes(ProductFeedSettingsPages.TARGET_COUNTRY) ? 1
+        : this.$route.path.includes(ProductFeedSettingsPages.SHIPPING_SETTINGS) ? 2
+          : this.$route.path.includes(ProductFeedSettingsPages.ATTRIBUTE_MAPPING) ? 3
+            : this.$route.path.includes(ProductFeedSettingsPages.SYNC_SCHEDULE) ? 4
+              : this.$route.path.includes(ProductFeedSettingsPages.SUMMARY) ? 5
+                : 1;
+      /* eslint-enable no-nested-ternary  */
     },
     steps() {
       return [
@@ -108,6 +116,7 @@ export default {
     },
   },
   mounted() {
+    console.log(this.$store.state.productFeed.stepper);
     this.$store.dispatch('productFeed/REQUEST_SHOP_TO_GET_ATTRIBUTE');
   },
   methods: {

--- a/_dev/src/components/product-feed/product-feed-settings.vue
+++ b/_dev/src/components/product-feed/product-feed-settings.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script>
-import {ProductFeedSettingsSteps} from '@/enums/product-feed/product-feed-settings-pages';
+import ProductFeedSettingsSteps from '@/enums/product-feed/product-feed-settings-steps';
 import Stepper from '../commons/stepper';
 import TargetCountry from './settings/target-countries/target-countries.vue';
 import ShippingSettings from './settings/shipping-settings/shipping-settings.vue';
@@ -85,9 +85,12 @@ export default {
       if (this.$store.state.productFeed.stepper > 0) {
         return this.$store.state.productFeed.stepper;
       }
-      const stepIs = ProductFeedSettingsSteps.indexOf(this.$route.params.step);
+      const indexOfRoute = ProductFeedSettingsSteps.indexOf(this.$route.params.step);
 
-      return stepIs;
+      if (indexOfRoute > 0) {
+        return indexOfRoute;
+      }
+      return 0;
     },
     steps() {
       return [

--- a/_dev/src/components/product-feed/settings/attribute-mapping/attribute-mapping.vue
+++ b/_dev/src/components/product-feed/settings/attribute-mapping/attribute-mapping.vue
@@ -111,6 +111,8 @@ import AttributeField from './attribute-field.vue';
 import CategoryButton from './category-button.vue';
 import googleUrl from '@/assets/json/googleUrl.json';
 import Categories from '@/enums/product-feed/attribute-mapping-categories';
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
+
 import {
   formatMappingToApi,
 } from '../../../../utils/AttributeMapping';
@@ -182,8 +184,20 @@ export default {
       localStorage.setItem('productFeed-attributeMapping', JSON.stringify(formatMappingToApi(this.attributesToMap)));
       if (this.$store.state.productFeed.settings.autoImportShippingSettings) {
         this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', 2);
+        this.$router.push({
+          name: 'product-feed-settings',
+          params: {
+            step: ProductFeedSettingsPages.SHIPPING_SETTINGS,
+          },
+        });
       } else {
         this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', 1);
+        this.$router.push({
+          name: 'product-feed-settings',
+          params: {
+            step: ProductFeedSettingsPages.TARGET_COUNTRY,
+          },
+        });
       }
       window.scrollTo(0, 0);
     },
@@ -194,6 +208,12 @@ export default {
       });
       localStorage.setItem('productFeed-attributeMapping', JSON.stringify(formatMappingToApi(this.attributesToMap)));
       this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', 4);
+      this.$router.push({
+        name: 'product-feed-settings',
+        params: {
+          step: ProductFeedSettingsPages.SYNC_SCHEDULE,
+        },
+      });
       window.scrollTo(0, 0);
     },
     cancel() {

--- a/_dev/src/components/product-feed/settings/shipping-settings/shipping-settings.vue
+++ b/_dev/src/components/product-feed/settings/shipping-settings/shipping-settings.vue
@@ -159,6 +159,7 @@
 </template>
 
 <script>
+import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
 import ShippingSettingsHeaderType from '@/enums/product-feed/shipping-settings-header-type.ts';
 import SettingsFooter from '@/components/product-feed/settings/commons/settings-footer.vue';
 import ActionsButtons from '@/components/product-feed/settings/commons/actions-buttons.vue';
@@ -217,6 +218,12 @@ export default {
     previousStep() {
       localStorage.setItem('productFeed-deliveryDetails', JSON.stringify(this.carriers));
       this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', 1);
+      this.$router.push({
+        name: 'product-feed-settings',
+        params: {
+          step: ProductFeedSettingsPages.TARGET_COUNTRY,
+        },
+      });
       window.scrollTo(0, 0);
     },
     nextStep() {
@@ -226,6 +233,12 @@ export default {
       });
       localStorage.setItem('productFeed-deliveryDetails', JSON.stringify(this.carriers));
       this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', 3);
+      this.$router.push({
+        name: 'product-feed-settings',
+        params: {
+          step: ProductFeedSettingsPages.ATTRIBUTE_MAPPING,
+        },
+      });
       window.scrollTo(0, 0);
     },
     cancel() {

--- a/_dev/src/components/product-feed/settings/shipping-settings/shipping-settings.vue
+++ b/_dev/src/components/product-feed/settings/shipping-settings/shipping-settings.vue
@@ -159,7 +159,7 @@
 </template>
 
 <script>
-import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
 import ShippingSettingsHeaderType from '@/enums/product-feed/shipping-settings-header-type.ts';
 import SettingsFooter from '@/components/product-feed/settings/commons/settings-footer.vue';
 import ActionsButtons from '@/components/product-feed/settings/commons/actions-buttons.vue';

--- a/_dev/src/components/product-feed/settings/shipping-settings/shipping-settings.vue
+++ b/_dev/src/components/product-feed/settings/shipping-settings/shipping-settings.vue
@@ -248,5 +248,8 @@ export default {
       this.$store.dispatch('productFeed/GET_SAVED_ADDITIONAL_SHIPPING_SETTINGS');
     },
   },
+  mounted() {
+    this.refreshComponent();
+  },
 };
 </script>

--- a/_dev/src/components/product-feed/settings/summary/summary.spec.ts
+++ b/_dev/src/components/product-feed/settings/summary/summary.spec.ts
@@ -9,6 +9,7 @@ import {cloneStore, filters, localVue} from '@/../tests/init';
 import ProductFeedSettingsSummary from '@/components/product-feed/settings/summary/summary.vue';
 import ProductFeedCardNextSyncCard from '@/components/product-feed/product-feed-card-next-sync-card.vue';
 import ActionsButtons from '@/components/product-feed/settings/commons/actions-buttons.vue';
+
 import {
   Summary,
 } from '@/../stories/product-feed-settings.stories';

--- a/_dev/src/components/product-feed/settings/summary/summary.vue
+++ b/_dev/src/components/product-feed/settings/summary/summary.vue
@@ -47,14 +47,16 @@
             :title="$t('productFeedSettings.shipping.targetCountries')"
             :description="targetCountries.join(', ')"
             :link="$t('cta.editCountries')"
-            :link-to="{ type: 'stepper', name: 1 }"
+            :link-to="{type : 'stepper', name: 'product-feed-settings',
+                       params: 'target-country'}"
           />
           <product-feed-card-report-card
             status="success"
             :title="$t('productFeedSettings.shipping.shippingSettings')"
             :description="shippingSettings"
             :link="$t('cta.editSettings')"
-            :link-to="{ type: 'stepper', name: 1 }"
+            :link-to="{type : 'stepper', name: 'product-feed-settings',
+                       params: 'shipping-settings'}"
           />
           <product-feed-card-report-card
             status="success"
@@ -70,7 +72,8 @@
             status="success"
             :title="$t('productFeedSettings.summary.productAttributesMapping')"
             :link="$t('cta.editProductAttributes')"
-            :link-to="{ type: 'stepper', name: 3 }"
+            :link-to="{type : 'stepper', name: 'product-feed-settings',
+                       params: 'attribute-mapping'}"
             size="full"
           >
             <b-table-simple
@@ -210,6 +213,7 @@ import duration from 'dayjs/plugin/duration';
 
 import {BTableSimple} from 'bootstrap-vue';
 import {VueShowdown} from 'vue-showdown';
+import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
 import googleUrl from '@/assets/json/googleUrl.json';
 import SettingsFooter from '@/components/product-feed/settings/commons/settings-footer.vue';
 import ActionsButtons from '@/components/product-feed/settings/commons/actions-buttons.vue';
@@ -337,6 +341,12 @@ export default {
     },
     previousStep() {
       this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', 4);
+      this.$router.push({
+        name: 'product-feed-settings',
+        params: {
+          step: ProductFeedSettingsPages.SYNC_SCHEDULE,
+        },
+      });
       window.scrollTo(0, 0);
     },
     postDatas() {
@@ -348,6 +358,7 @@ export default {
       this.disabledExportButton = false;
     },
   },
+
   googleUrl,
 };
 </script>

--- a/_dev/src/components/product-feed/settings/summary/summary.vue
+++ b/_dev/src/components/product-feed/settings/summary/summary.vue
@@ -47,7 +47,7 @@
             :title="$t('productFeedSettings.shipping.targetCountries')"
             :description="targetCountries.join(', ')"
             :link="$t('cta.editCountries')"
-            :link-to="{ type: 'routeStep', name: 'product-feed-settings',
+            :link-to="{ name: 'product-feed-settings',
                         step: 1, params: ProductFeedSettingsPages.TARGET_COUNTRY }"
           />
           <product-feed-card-report-card
@@ -55,8 +55,8 @@
             :title="$t('productFeedSettings.shipping.shippingSettings')"
             :description="shippingSettings"
             :link="$t('cta.editSettings')"
-            :link-to="{type : 'routeStep', name: 'product-feed-settings',
-                       step: 2,params: ProductFeedSettingsPages.SHIPPING_SETTINGS}"
+            :link-to="{ name: 'product-feed-settings',
+                        step: 2,params: ProductFeedSettingsPages.SHIPPING_SETTINGS}"
           />
           <product-feed-card-report-card
             status="success"
@@ -72,8 +72,8 @@
             status="success"
             :title="$t('productFeedSettings.summary.productAttributesMapping')"
             :link="$t('cta.editProductAttributes')"
-            :link-to="{type : 'routeStep', name: 'product-feed-settings',
-                       step: 3,params: ProductFeedSettingsPages.ATTRIBUTE_MAPPING}"
+            :link-to="{ name: 'product-feed-settings',
+                        step: 3,params: ProductFeedSettingsPages.ATTRIBUTE_MAPPING}"
             size="full"
           >
             <b-table-simple

--- a/_dev/src/components/product-feed/settings/summary/summary.vue
+++ b/_dev/src/components/product-feed/settings/summary/summary.vue
@@ -213,7 +213,7 @@ import duration from 'dayjs/plugin/duration';
 
 import {BTableSimple} from 'bootstrap-vue';
 import {VueShowdown} from 'vue-showdown';
-import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
 import googleUrl from '@/assets/json/googleUrl.json';
 import SettingsFooter from '@/components/product-feed/settings/commons/settings-footer.vue';
 import ActionsButtons from '@/components/product-feed/settings/commons/actions-buttons.vue';

--- a/_dev/src/components/product-feed/settings/summary/summary.vue
+++ b/_dev/src/components/product-feed/settings/summary/summary.vue
@@ -47,16 +47,16 @@
             :title="$t('productFeedSettings.shipping.targetCountries')"
             :description="targetCountries.join(', ')"
             :link="$t('cta.editCountries')"
-            :link-to="{type : 'stepper', name: 'product-feed-settings',
-                       params: 'target-country'}"
+            :link-to="{ type: 'routeStep', name: 'product-feed-settings',
+                        step: 1, params: ProductFeedSettingsPages.TARGET_COUNTRY }"
           />
           <product-feed-card-report-card
             status="success"
             :title="$t('productFeedSettings.shipping.shippingSettings')"
             :description="shippingSettings"
             :link="$t('cta.editSettings')"
-            :link-to="{type : 'stepper', name: 'product-feed-settings',
-                       params: 'shipping-settings'}"
+            :link-to="{type : 'routeStep', name: 'product-feed-settings',
+                       step: 2,params: ProductFeedSettingsPages.SHIPPING_SETTINGS}"
           />
           <product-feed-card-report-card
             status="success"
@@ -72,8 +72,8 @@
             status="success"
             :title="$t('productFeedSettings.summary.productAttributesMapping')"
             :link="$t('cta.editProductAttributes')"
-            :link-to="{type : 'stepper', name: 'product-feed-settings',
-                       params: 'attribute-mapping'}"
+            :link-to="{type : 'routeStep', name: 'product-feed-settings',
+                       step: 3,params: ProductFeedSettingsPages.ATTRIBUTE_MAPPING}"
             size="full"
           >
             <b-table-simple
@@ -237,7 +237,9 @@ export default {
   },
   data() {
     return {
-      shippingSettings: this.$store.state.productFeed.settings.autoImportShippingSettings
+      ProductFeedSettingsPages,
+      shippingSettings:
+      this.$store.state.productFeed.settings.autoImportShippingSettings
         ? this.$t('productFeedSettings.shipping.automatically')
         : this.$t('productFeedSettings.shipping.manually'),
       refurbishedInputs: ['condition'],

--- a/_dev/src/components/product-feed/settings/sync-schedule/sync-schedule.vue
+++ b/_dev/src/components/product-feed/settings/sync-schedule/sync-schedule.vue
@@ -37,7 +37,7 @@
   </div>
 </template>
 <script>
-import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
 import SettingsFooter from '@/components/product-feed/settings/commons/settings-footer.vue';
 import ActionsButtons from '@/components/product-feed/settings/commons/actions-buttons.vue';
 import SegmentGenericParams from '@/utils/SegmentGenericParams';

--- a/_dev/src/components/product-feed/settings/sync-schedule/sync-schedule.vue
+++ b/_dev/src/components/product-feed/settings/sync-schedule/sync-schedule.vue
@@ -37,6 +37,7 @@
   </div>
 </template>
 <script>
+import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
 import SettingsFooter from '@/components/product-feed/settings/commons/settings-footer.vue';
 import ActionsButtons from '@/components/product-feed/settings/commons/actions-buttons.vue';
 import SegmentGenericParams from '@/utils/SegmentGenericParams';
@@ -66,6 +67,12 @@ export default {
   methods: {
     previousStep() {
       this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', 3);
+      this.$router.push({
+        params: {
+          name: 'product-feed-settings',
+          step: ProductFeedSettingsPages.ATTRIBUTE_MAPPING,
+        },
+      });
       window.scrollTo(0, 0);
     },
     nextStep() {
@@ -74,6 +81,12 @@ export default {
         params: SegmentGenericParams,
       });
       this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', 5);
+      this.$router.push({
+        name: 'product-feed-settings',
+        params: {
+          step: ProductFeedSettingsPages.SUMMARY,
+        },
+      });
       window.scrollTo(0, 0);
     },
     cancel() {

--- a/_dev/src/components/product-feed/settings/target-countries/target-countries.vue
+++ b/_dev/src/components/product-feed/settings/target-countries/target-countries.vue
@@ -105,6 +105,7 @@
 
 <script>
 import {VueShowdown} from 'vue-showdown';
+import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
 import SettingsFooter from '@/components/product-feed/settings/commons/settings-footer.vue';
 import ActionsButtons from '@/components/product-feed/settings/commons/actions-buttons.vue';
 import SelectCountry from '@/components/commons/select-country.vue';
@@ -165,6 +166,13 @@ export default {
             data: true,
           });
           this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', 2);
+          this.$router.push({
+            name: 'product-feed-settings',
+            params: {
+              step: ProductFeedSettingsPages.SHIPPING_SETTINGS
+              ,
+            },
+          });
           window.scrollTo(0, 0);
         });
       } else {
@@ -177,6 +185,12 @@ export default {
           data: false,
         });
         this.$store.commit('productFeed/SET_ACTIVE_CONFIGURATION_STEP', 3);
+        this.$router.push({
+          name: 'product-feed-settings',
+          params: {
+            step: ProductFeedSettingsPages.ATTRIBUTE_MAPPING,
+          },
+        });
         window.scrollTo(0, 0);
       }
     },

--- a/_dev/src/components/product-feed/settings/target-countries/target-countries.vue
+++ b/_dev/src/components/product-feed/settings/target-countries/target-countries.vue
@@ -105,7 +105,7 @@
 
 <script>
 import {VueShowdown} from 'vue-showdown';
-import ProductFeedSettingsPages from '@enums/product-feed/product-feed-settings-pages';
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
 import SettingsFooter from '@/components/product-feed/settings/commons/settings-footer.vue';
 import ActionsButtons from '@/components/product-feed/settings/commons/actions-buttons.vue';
 import SelectCountry from '@/components/commons/select-country.vue';

--- a/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation.vue
+++ b/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation.vue
@@ -742,10 +742,10 @@ export default {
   },
   mounted() {
     window.scrollTo(0, 0);
-    if (
-      this.editMode === true
-      && this.foundSsc !== undefined
-    ) {
+    if (this.productsHaveBeenApprovedByGoogle) {
+      this.getDatasFiltersDimensions();
+    }
+    if (this.editMode === true && this.foundSsc !== undefined) {
       this.setInterfaceForEdition();
     } else {
       this.loader = false;

--- a/_dev/src/components/smart-shopping-campaign/reporting/key-metrics/key-metrics-block.vue
+++ b/_dev/src/components/smart-shopping-campaign/reporting/key-metrics/key-metrics-block.vue
@@ -7,9 +7,13 @@
       <p class="flex-shrink-0 mb-2 ps_gs-onboardingcard__title mb-sm-0">
         {{ $t('keymetrics.title') }}
       </p>
-      <KeyMetricsPeriodSelector />
+      <KeyMetricsPeriodSelector :in-need-of-configuration="inNeedOfConfiguration" />
     </template>
-    <KeyMetricsErrorMessage v-if="errorWithApi" />
+    <NotConfiguredCard
+      v-if="inNeedOfConfiguration"
+      class="mx-auto"
+    />
+    <KeyMetricsErrorMessage v-else-if="errorWithApi && !inNeedOfConfiguration" />
     <div v-else>
       <div class="mt-2 d-flex justify-content-between flex-column flex-sm-row">
         <div class="order-1 mb-2 order-sm-0">
@@ -61,6 +65,7 @@ import KeyMetricsKpiCardGroup from './key-metrics-kpi-card-group.vue';
 import KeyMetricsKpiCard from './key-metrics-kpi-card.vue';
 import KeyMetricsChartWrapper from './key-metrics-chart-wrapper.vue';
 import googleUrl from '@/assets/json/googleUrl.json';
+import NotConfiguredCard from '@/components/commons/not-configured-card.vue';
 
 export default {
   name: 'KeyMetricsBlock',
@@ -70,6 +75,13 @@ export default {
     KeyMetricsKpiCardGroup,
     KeyMetricsKpiCard,
     KeyMetricsChartWrapper,
+    NotConfiguredCard,
+  },
+  props: {
+    inNeedOfConfiguration: {
+      type: Boolean,
+      required: true,
+    },
   },
   computed: {
     reportingKpis() {

--- a/_dev/src/components/smart-shopping-campaign/reporting/key-metrics/key-metrics-period-selector.vue
+++ b/_dev/src/components/smart-shopping-campaign/reporting/key-metrics/key-metrics-period-selector.vue
@@ -9,6 +9,7 @@
         size="sm"
         v-model="reportingPeriod"
         :options="periods"
+        :disabled="inNeedOfConfiguration"
       />
     </b-form-group>
     <b-dropdown
@@ -24,6 +25,7 @@
         :key="value"
         link-class="flex-wrap px-3 d-flex flex-md-nowrap align-items-center"
         @click="reportingPeriod = value"
+        :disabled="inNeedOfConfiguration"
       >
         {{ text }}
       </b-dropdown-item>
@@ -36,6 +38,12 @@ import ReportingPeriod from '@/enums/reporting/ReportingPeriod';
 
 export default {
   name: 'KeyMetricsPeriodSelector',
+  props: {
+    inNeedOfConfiguration: {
+      type: Boolean,
+      required: true,
+    },
+  },
   data() {
     return {
       periods: [

--- a/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list.vue
+++ b/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list.vue
@@ -296,7 +296,7 @@ export default {
     }
 
     if (this.inNeedOfConfiguration) {
-      this.$emit('loader', false)
+      this.$emit('loader', false);
       return;
     }
     this.fetchCampaigns();

--- a/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list.vue
+++ b/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list.vue
@@ -1,12 +1,26 @@
 <template>
   <div>
-    <div class="d-flex flex-wrap flex-md-nowrap justify-content-between mb-md-3 rounded-top">
+    <div
+      v-if="inNeedOfConfiguration"
+      class="ps_gs-onboardingcard__not-configured"
+    >
+      <NotConfiguredCard />
+    </div>
+    <div class="d-flex flex-wrap flex-md-nowrap justify-content-between  mb-md-3 rounded-top">
       <h3 class="order-2 order-md-1 ps_gs-fz-20 font-weight-600">
-        {{ $t('smartShoppingCampaignList.tableTitle') }}
+        {{ $t("smartShoppingCampaignList.tableTitle") }}
       </h3>
       <div
-        class="order-1 order-md-2 ml-auto d-flex-md mr-md-0 mb-2 mt-n3 mt-md-0
-        flex-md-shrink-0 text-center"
+        class="
+          order-1 order-md-2
+          ml-auto
+          d-flex-md
+          mr-md-0
+          mb-2
+          mt-n3 mt-md-0
+          flex-md-shrink-0
+          text-center
+        "
       >
         <b-button
           v-if="remarketingTag"
@@ -15,7 +29,7 @@
           variant="outline-primary"
           @click="redirectToReporting"
         >
-          {{ $t('cta.viewReporting') }}
+          {{ $t("cta.viewReporting") }}
         </b-button>
         <b-button
           size="sm"
@@ -23,13 +37,16 @@
           variant="primary"
           @click="redirectToCreateCampaign"
         >
-          {{ $t('cta.createCampaign') }}
+          {{ $t("cta.createCampaign") }}
         </b-button>
       </div>
     </div>
     <ReportingTableHeader
-      :title="$tc(`smartShoppingCampaignList.xCampaign`,
-                  campaignList.length, [campaignList.length])"
+      :title="
+        $tc(`smartShoppingCampaignList.xCampaign`, campaignList.length, [
+          campaignList.length,
+        ])
+      "
       :use-date="false"
     />
     <!-- TODO : use this header when API returs only GMC linked campaigns -->
@@ -45,8 +62,13 @@
     <div>
       <b-table-simple
         id="table-filters-performance"
-        class="ps_gs-table-products mb-0 table-with-maxheight b-table-sticky-header"
-        :table-class="{'border-bottom-0': loading}"
+        class="
+          ps_gs-table-products
+          mb-0
+          table-with-maxheight
+          b-table-sticky-header
+        "
+        :table-class="{ 'border-bottom-0': loading }"
         variant="light"
         responsive="xl"
       >
@@ -56,7 +78,10 @@
               v-for="(type, index) in campaignHeaderList"
               :key="type"
               class="font-weight-600"
-              :class="{'b-table-sticky-column b-table-sticky-column--invisible': index === 0}"
+              :class="{
+                'b-table-sticky-column b-table-sticky-column--invisible':
+                  index === 0,
+              }"
             >
               <div class="flex align-items-center text-nowrap">
                 <b-button
@@ -68,11 +93,11 @@
                   <span>{{ $t(`campaigns.labelCol.${type}`) }}</span>
                   <template v-if="queryOrderDirection[type] === 'ASC'">
                     <i class="material-icons ps_gs-fz-14">expand_more</i>
-                    <span class="sr-only">{{ $t('cta.clickToSortAsc') }}</span>
+                    <span class="sr-only">{{ $t("cta.clickToSortAsc") }}</span>
                   </template>
                   <template v-else>
                     <i class="material-icons ps_gs-fz-14">expand_less</i>
-                    <span class="sr-only">{{ $t('cta.clickToSortDesc') }}</span>
+                    <span class="sr-only">{{ $t("cta.clickToSortDesc") }}</span>
                   </template>
                 </b-button>
                 <span v-else>
@@ -83,9 +108,18 @@
                   variant="invisible"
                   v-b-tooltip:psxMktgWithGoogleApp
                   :title="$t(`campaigns.tooltipCol.${type}`)"
-                  class="p-0 mt-0 ml-1 border-0 d-inline-flex align-items-center"
+                  class="
+                    p-0
+                    mt-0
+                    ml-1
+                    border-0
+                    d-inline-flex
+                    align-items-center
+                  "
                 >
-                  <i class="material-icons ps_gs-fz-14 text-secondary">info_outlined</i>
+                  <i
+                    class="material-icons ps_gs-fz-14 text-secondary"
+                  >info_outlined</i>
                 </b-button>
               </div>
             </b-th>
@@ -95,14 +129,20 @@
               v-for="(type, index) in campaignHeaderList"
               :key="type"
               class="font-weight-600"
-              :class="{'b-table-sticky-column b-table-sticky-column--invisible': index === 0}"
+              :class="{
+                'b-table-sticky-column b-table-sticky-column--invisible':
+                  index === 0,
+              }"
             >
               <b-form-input
                 v-if="hasInput(type)"
                 id="campaign-name-input-filter"
                 v-model="campaignName"
-                :placeholder="$t('general.searchByX',
-                                 [$t(`campaigns.labelCol.${type}`).toLowerCase()])"
+                :placeholder="
+                  $t('general.searchByX', [
+                    $t(`campaigns.labelCol.${type}`).toLowerCase(),
+                  ])
+                "
                 size="sm"
                 class="border-0"
                 type="text"
@@ -139,12 +179,14 @@ import ReportingTableHeader from './reporting/commons/reporting-table-header.vue
 import CampaignSummaryListHeaderType from '@/enums/campaigns-summary/CampaignSummaryListHeaderType';
 import QueryOrderDirection from '@/enums/reporting/QueryOrderDirection';
 import googleUrl from '../../assets/json/googleUrl.json';
+import NotConfiguredCard from '@/components/commons/not-configured-card.vue';
 
 export default {
   name: 'SmartShoppingCampaignTableList',
   components: {
     SmartShoppingCampaignTableListRow,
     ReportingTableHeader,
+    NotConfiguredCard,
   },
   data() {
     return {
@@ -154,6 +196,10 @@ export default {
   },
   props: {
     loading: {
+      type: Boolean,
+      required: true,
+    },
+    inNeedOfConfiguration: {
       type: Boolean,
       required: true,
     },
@@ -168,7 +214,9 @@ export default {
 
       if (searchQuery) {
         return campaigns.filter((campaign) => {
-          const nameMatch = campaign.campaignName.toLowerCase().includes(searchQuery.toLowerCase());
+          const nameMatch = campaign.campaignName
+            .toLowerCase()
+            .includes(searchQuery.toLowerCase());
 
           return nameMatch;
         });
@@ -177,15 +225,22 @@ export default {
     },
     queryOrderDirection: {
       get() {
-        return this.$store.getters['smartShoppingCampaigns/GET_SSC_LIST_ORDERING'];
+        return this.$store.getters[
+          'smartShoppingCampaigns/GET_SSC_LIST_ORDERING'
+        ];
       },
       set(orderDirection) {
-        this.$store.commit('smartShoppingCampaigns/SET_SSC_LIST_ORDERING', orderDirection);
+        this.$store.commit(
+          'smartShoppingCampaigns/SET_SSC_LIST_ORDERING',
+          orderDirection,
+        );
         this.fetchCampaigns();
       },
     },
     remarketingTag() {
-      return this.$store.getters['smartShoppingCampaigns/GET_REMARKETING_TRACKING_TAG_STATUS'];
+      return this.$store.getters[
+        'smartShoppingCampaigns/GET_REMARKETING_TRACKING_TAG_STATUS'
+      ];
     },
   },
   methods: {
@@ -213,7 +268,9 @@ export default {
       // create new object for satisfy deep getter of vueJS
       const newOrderDirection = {...this.queryOrderDirection};
 
-      if (this.queryOrderDirection[headerType] === QueryOrderDirection.ASCENDING) {
+      if (
+        this.queryOrderDirection[headerType] === QueryOrderDirection.ASCENDING
+      ) {
         newOrderDirection[headerType] = QueryOrderDirection.DESCENDING;
       } else {
         newOrderDirection[headerType] = QueryOrderDirection.ASCENDING;
@@ -225,14 +282,17 @@ export default {
       this.$emit('loader', true);
       clearTimeout(this.timer);
       this.timer = setTimeout(() => {
-        this.$store.commit('smartShoppingCampaigns/SET_SSC_LIST_ORDERING', {name: this.campaignName});
+        this.$store.commit('smartShoppingCampaigns/SET_SSC_LIST_ORDERING', {
+          name: this.campaignName,
+        });
         this.fetchCampaigns();
       }, 1000);
     },
 
     fetchCampaigns(isNewRequest = true) {
       this.$emit('loader', true);
-      this.$store.dispatch('smartShoppingCampaigns/GET_SSC_LIST', isNewRequest)
+      this.$store
+        .dispatch('smartShoppingCampaigns/GET_SSC_LIST', isNewRequest)
         .finally(() => {
           this.$emit('loader', false);
         });
@@ -242,17 +302,23 @@ export default {
         return;
       }
       const body = document.getElementsByClassName('table-with-maxheight')[0];
-      const token = this.$store.getters['smartShoppingCampaigns/GET_TOKEN_NEXT_PAGE_CAMPAIGN_LIST'];
+      const token = this.$store.getters[
+        'smartShoppingCampaigns/GET_TOKEN_NEXT_PAGE_CAMPAIGN_LIST'
+      ];
 
-      if (body.scrollTop >= body.scrollHeight - body.clientHeight
-      && body.scrollTop > 0
-      && token !== null) {
+      if (
+        body.scrollTop >= body.scrollHeight - body.clientHeight
+        && body.scrollTop > 0
+        && token !== null
+      ) {
         this.fetchCampaigns(false);
       }
     },
   },
   mounted() {
-    const tableBody = document.getElementsByClassName('table-with-maxheight')[0];
+    const tableBody = document.getElementsByClassName(
+      'table-with-maxheight',
+    )[0];
 
     if (tableBody) {
       tableBody.addEventListener('scroll', this.handleScroll);
@@ -261,13 +327,14 @@ export default {
     this.fetchCampaigns();
   },
   beforeDestroy() {
-    const tableBody = document.getElementsByClassName('table-with-maxheight')[0];
+    const tableBody = document.getElementsByClassName(
+      'table-with-maxheight',
+    )[0];
 
     if (tableBody) {
       tableBody.removeEventListener('scroll', this.handleScroll);
     }
   },
   googleUrl,
-
 };
 </script>

--- a/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list.vue
+++ b/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list.vue
@@ -1,26 +1,15 @@
 <template>
   <div>
     <div
-      v-if="inNeedOfConfiguration"
-      class="ps_gs-onboardingcard__not-configured"
+      v-if="!inNeedOfConfiguration"
+      class="d-flex flex-wrap flex-md-nowrap justify-content-between mb-md-3 rounded-top"
     >
-      <NotConfiguredCard />
-    </div>
-    <div class="d-flex flex-wrap flex-md-nowrap justify-content-between  mb-md-3 rounded-top">
       <h3 class="order-2 order-md-1 ps_gs-fz-20 font-weight-600">
-        {{ $t("smartShoppingCampaignList.tableTitle") }}
+        {{ $t('smartShoppingCampaignList.tableTitle') }}
       </h3>
       <div
-        class="
-          order-1 order-md-2
-          ml-auto
-          d-flex-md
-          mr-md-0
-          mb-2
-          mt-n3 mt-md-0
-          flex-md-shrink-0
-          text-center
-        "
+        class="order-1 order-md-2 ml-auto d-flex-md mr-md-0 mb-2 mt-n3 mt-md-0
+        flex-md-shrink-0 text-center"
       >
         <b-button
           v-if="remarketingTag"
@@ -29,7 +18,7 @@
           variant="outline-primary"
           @click="redirectToReporting"
         >
-          {{ $t("cta.viewReporting") }}
+          {{ $t('cta.viewReporting') }}
         </b-button>
         <b-button
           size="sm"
@@ -37,16 +26,14 @@
           variant="primary"
           @click="redirectToCreateCampaign"
         >
-          {{ $t("cta.createCampaign") }}
+          {{ $t('cta.createCampaign') }}
         </b-button>
       </div>
     </div>
     <ReportingTableHeader
-      :title="
-        $tc(`smartShoppingCampaignList.xCampaign`, campaignList.length, [
-          campaignList.length,
-        ])
-      "
+      v-if="!inNeedOfConfiguration"
+      :title="$tc(`smartShoppingCampaignList.xCampaign`,
+                  campaignList.length, [campaignList.length])"
       :use-date="false"
     />
     <!-- TODO : use this header when API returs only GMC linked campaigns -->
@@ -62,13 +49,9 @@
     <div>
       <b-table-simple
         id="table-filters-performance"
-        class="
-          ps_gs-table-products
-          mb-0
-          table-with-maxheight
-          b-table-sticky-header
-        "
-        :table-class="{ 'border-bottom-0': loading }"
+        class="ps_gs-table-products mb-0"
+        :class="{'table-with-maxheight b-table-sticky-header' : !inNeedOfConfiguration}"
+        :table-class="{'border-bottom-0': loading}"
         variant="light"
         responsive="xl"
       >
@@ -78,14 +61,11 @@
               v-for="(type, index) in campaignHeaderList"
               :key="type"
               class="font-weight-600"
-              :class="{
-                'b-table-sticky-column b-table-sticky-column--invisible':
-                  index === 0,
-              }"
+              :class="{'b-table-sticky-column b-table-sticky-column--invisible': index === 0}"
             >
               <div class="flex align-items-center text-nowrap">
                 <b-button
-                  v-if="hasSorting(type)"
+                  v-if="hasSorting(type) && !inNeedOfConfiguration"
                   @click="sortByType(type)"
                   variant="invisible"
                   class="p-0 border-0"
@@ -93,33 +73,24 @@
                   <span>{{ $t(`campaigns.labelCol.${type}`) }}</span>
                   <template v-if="queryOrderDirection[type] === 'ASC'">
                     <i class="material-icons ps_gs-fz-14">expand_more</i>
-                    <span class="sr-only">{{ $t("cta.clickToSortAsc") }}</span>
+                    <span class="sr-only">{{ $t('cta.clickToSortAsc') }}</span>
                   </template>
                   <template v-else>
                     <i class="material-icons ps_gs-fz-14">expand_less</i>
-                    <span class="sr-only">{{ $t("cta.clickToSortDesc") }}</span>
+                    <span class="sr-only">{{ $t('cta.clickToSortDesc') }}</span>
                   </template>
                 </b-button>
                 <span v-else>
                   {{ $t(`campaigns.labelCol.${type}`) }}
                 </span>
                 <b-button
-                  v-if="hasToolTip(type)"
+                  v-if="hasToolTip(type) && !inNeedOfConfiguration"
                   variant="invisible"
                   v-b-tooltip:psxMktgWithGoogleApp
                   :title="$t(`campaigns.tooltipCol.${type}`)"
-                  class="
-                    p-0
-                    mt-0
-                    ml-1
-                    border-0
-                    d-inline-flex
-                    align-items-center
-                  "
+                  class="p-0 mt-0 ml-1 border-0 d-inline-flex align-items-center"
                 >
-                  <i
-                    class="material-icons ps_gs-fz-14 text-secondary"
-                  >info_outlined</i>
+                  <i class="material-icons ps_gs-fz-14 text-secondary">info_outlined</i>
                 </b-button>
               </div>
             </b-th>
@@ -129,23 +100,18 @@
               v-for="(type, index) in campaignHeaderList"
               :key="type"
               class="font-weight-600"
-              :class="{
-                'b-table-sticky-column b-table-sticky-column--invisible':
-                  index === 0,
-              }"
+              :class="{'b-table-sticky-column b-table-sticky-column--invisible': index === 0}"
             >
               <b-form-input
                 v-if="hasInput(type)"
                 id="campaign-name-input-filter"
                 v-model="campaignName"
-                :placeholder="
-                  $t('general.searchByX', [
-                    $t(`campaigns.labelCol.${type}`).toLowerCase(),
-                  ])
-                "
+                :placeholder="$t('general.searchByX',
+                                 [$t(`campaigns.labelCol.${type}`).toLowerCase()])"
                 size="sm"
                 class="border-0"
                 type="text"
+                :disabled="!!inNeedOfConfiguration"
                 @keyup="debounceName()"
               />
             </b-th>
@@ -159,9 +125,14 @@
               :campaign="campaign"
             />
           </template>
+          <b-tr v-if="!!inNeedOfConfiguration">
+            <b-td :colspan="campaignHeaderList.length">
+              <NotConfiguredCard class="mx-auto" />
+            </b-td>
+          </b-tr>
           <b-tr v-if="loading">
             <b-td
-              colspan="7"
+              :colspan="campaignHeaderList.length"
               class="ps_gs-table-products__loading-slot"
             >
               <i class="ps_gs-table-products__spinner">loading</i>
@@ -324,6 +295,10 @@ export default {
       tableBody.addEventListener('scroll', this.handleScroll);
     }
 
+    if (this.inNeedOfConfiguration) {
+      this.loading = false;
+      return;
+    }
     this.fetchCampaigns();
   },
   beforeDestroy() {

--- a/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list.vue
+++ b/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list.vue
@@ -296,7 +296,7 @@ export default {
     }
 
     if (this.inNeedOfConfiguration) {
-      this.loading = false;
+      this.$emit('loader', false)
       return;
     }
     this.fetchCampaigns();

--- a/_dev/src/enums/product-feed/product-feed-settings-pages.ts
+++ b/_dev/src/enums/product-feed/product-feed-settings-pages.ts
@@ -6,4 +6,13 @@ enum ProductFeedSettingsPages {
   SUMMARY = 'summary',
 }
 
+export const ProductFeedSettingsSteps = [
+  null,
+  ProductFeedSettingsPages.TARGET_COUNTRY,
+  ProductFeedSettingsPages.SHIPPING_SETTINGS,
+  ProductFeedSettingsPages.ATTRIBUTE_MAPPING,
+  ProductFeedSettingsPages.SYNC_SCHEDULE,
+  ProductFeedSettingsPages.SUMMARY,
+];
+
 export default ProductFeedSettingsPages;

--- a/_dev/src/enums/product-feed/product-feed-settings-pages.ts
+++ b/_dev/src/enums/product-feed/product-feed-settings-pages.ts
@@ -1,18 +1,9 @@
-enum ProductFeedSettingsPages {
+ enum ProductFeedSettingsPages {
   TARGET_COUNTRY = 'target-country',
   SHIPPING_SETTINGS = 'shipping-settings',
   ATTRIBUTE_MAPPING = 'attribute-mapping',
   SYNC_SCHEDULE = 'sync-schedule',
   SUMMARY = 'summary',
 }
-
-export const ProductFeedSettingsSteps = [
-  null,
-  ProductFeedSettingsPages.TARGET_COUNTRY,
-  ProductFeedSettingsPages.SHIPPING_SETTINGS,
-  ProductFeedSettingsPages.ATTRIBUTE_MAPPING,
-  ProductFeedSettingsPages.SYNC_SCHEDULE,
-  ProductFeedSettingsPages.SUMMARY,
-];
 
 export default ProductFeedSettingsPages;

--- a/_dev/src/enums/product-feed/product-feed-settings-pages.ts
+++ b/_dev/src/enums/product-feed/product-feed-settings-pages.ts
@@ -1,0 +1,9 @@
+enum ProductFeedSettingsPages {
+  TARGET_COUNTRY = 'target-country',
+  SHIPPING_SETTINGS = 'shipping-settings',
+  ATTRIBUTE_MAPPING = 'attribute-mapping',
+  SYNC_SCHEDULE = 'sync-schedule',
+  SUMMARY = 'summary',
+}
+
+export default ProductFeedSettingsPages;

--- a/_dev/src/enums/product-feed/product-feed-settings-steps.ts
+++ b/_dev/src/enums/product-feed/product-feed-settings-steps.ts
@@ -1,0 +1,11 @@
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
+
+const ProductFeedSettingsSteps = [
+  null,
+  ProductFeedSettingsPages.TARGET_COUNTRY,
+  ProductFeedSettingsPages.SHIPPING_SETTINGS,
+  ProductFeedSettingsPages.ATTRIBUTE_MAPPING,
+  ProductFeedSettingsPages.SYNC_SCHEDULE,
+  ProductFeedSettingsPages.SUMMARY,
+];
+export default ProductFeedSettingsSteps;

--- a/_dev/src/router/index.ts
+++ b/_dev/src/router/index.ts
@@ -9,34 +9,39 @@ import Configuration from '../views/configuration.vue';
 import ProductFeedPage from '../views/product-feed-page.vue';
 import ReportingPage from '../views/reporting-page.vue';
 import TunnelProductFeed from '../views/tunnel-product-feed.vue';
+import {getDataFromLocalStorage} from '@/utils/LocalStorage';
 
 Vue.use(VueRouter);
 
 const initialPath = (to, from, next) => {
   if (from.path === '/'
-    && (!Store.getters['accounts/GET_PS_ACCOUNTS_IS_ONBOARDED']
-      || Store.getters['accounts/GET_PS_ACCOUNTS_CONTEXT_SHOPS'].length)
+    && Store.getters['accounts/GET_PS_ACCOUNTS_IS_ONBOARDED'] === false
   ) {
-    next({name: 'landingPage'});
+    next({name: 'landing-page'});
   } else {
     next({name: 'configuration'});
   }
 };
 
 const landingExistsInLocalstorage = (to, from, next) => {
-  let existInLocalstorage = window.localStorage.getItem('landingHasBeenSeen') || '';
-  existInLocalstorage = JSON.parse(existInLocalstorage);
-  if (existInLocalstorage) {
+  if (getDataFromLocalStorage('landingHasBeenSeen')) {
     next();
   } else {
-    next({name: 'landingPage'});
+    next({name: 'landing-page'});
   }
+};
+
+const campaignsAlreadyExist = (to, from, next) => {
+  if (!Store.getters['smartShoppingCampaigns/GET_ALL_SSC'].length) {
+    next();
+  }
+  next({name: 'campaign-list'});
 };
 
 const routes: Array<RouteConfig> = [
   {
     path: '/landing-page',
-    name: 'landingPage',
+    name: 'landing-page',
     component: LandingPage,
   },
   {
@@ -73,21 +78,22 @@ const routes: Array<RouteConfig> = [
   // },
   {
     path: '/campaign',
-    name: 'campaign',
+    name: 'campaign-info',
     component: CampaignPage,
+    beforeEnter: campaignsAlreadyExist,
   },
   {
-    path: '/campaign/creation',
-    name: 'campaign-creation',
-    component: CampaignPage,
-  },
-  {
-    path: '/campaign/list',
+    path: '/campaign-list',
     name: 'campaign-list',
     component: CampaignPage,
   },
   {
-    path: '/campaign/edit/:id',
+    path: '/campaign-creation',
+    name: 'campaign-creation',
+    component: CampaignPage,
+  },
+  {
+    path: '/campaign-edit/:id',
     name: 'campaign-edition',
     component: CampaignPage,
   },

--- a/_dev/src/router/index.ts
+++ b/_dev/src/router/index.ts
@@ -78,12 +78,12 @@ const routes: Array<RouteConfig> = [
   // },
   {
     path: '/campaign',
-    name: 'campaign-info',
+    name: 'campaign',
     component: CampaignPage,
     beforeEnter: campaignsAlreadyExist,
   },
   {
-    path: '/campaign-list',
+    path: '/campaign/list',
     name: 'campaign-list',
     component: CampaignPage,
   },

--- a/_dev/src/router/index.ts
+++ b/_dev/src/router/index.ts
@@ -2,10 +2,10 @@ import Vue from 'vue';
 import VueRouter, {RouteConfig} from 'vue-router';
 import Store from '../store';
 import CampaignPage from '../views/campaign-page.vue';
-import Configuration from '../views/configuration.vue';
+import LandingPage from '../views/landing-page.vue';
 import Debug from '../views/debug.vue';
 import Help from '../views/help.vue';
-import OnboardingPage from '../views/onboarding-page.vue';
+import Configuration from '../views/configuration.vue';
 import ProductFeedPage from '../views/product-feed-page.vue';
 import ReportingPage from '../views/reporting-page.vue';
 import TunnelProductFeed from '../views/tunnel-product-feed.vue';
@@ -17,25 +17,36 @@ const initialPath = (to, from, next) => {
     && (!Store.getters['accounts/GET_PS_ACCOUNTS_IS_ONBOARDED']
       || Store.getters['accounts/GET_PS_ACCOUNTS_CONTEXT_SHOPS'].length)
   ) {
-    next({name: 'configuration'});
+    next({name: 'landingPage'});
   } else {
-    next({name: 'onboarding'});
+    next({name: 'configuration'});
+  }
+};
+
+const landingExistsInLocalstorage = (to, from, next) => {
+  let existInLocalstorage = window.localStorage.getItem('landingHasBeenSeen') || '';
+  existInLocalstorage = JSON.parse(existInLocalstorage);
+  if (existInLocalstorage) {
+    next();
+  } else {
+    next({name: 'landingPage'});
   }
 };
 
 const routes: Array<RouteConfig> = [
   {
+    path: '/landing-page',
+    name: 'landingPage',
+    component: LandingPage,
+  },
+  {
     path: '/configuration',
     name: 'configuration',
     component: Configuration,
+    beforeEnter: landingExistsInLocalstorage,
   },
   {
-    path: '/configuration/onboarding',
-    name: 'onboarding',
-    component: OnboardingPage,
-  },
-  {
-    path: '/configuration/product-feed-settings',
+    path: '/configuration/product-feed-settings/:step',
     name: 'product-feed-settings',
     component: TunnelProductFeed,
   },

--- a/_dev/src/store/modules/product-feed/state.ts
+++ b/_dev/src/store/modules/product-feed/state.ts
@@ -127,7 +127,7 @@ export const state: State = {
   isConfigured: false,
   isConfiguredOnce: false,
   totalProducts: 0,
-  stepper: 1,
+  stepper: 0,
   status: {
     success: false,
     jobEndedAt: '',

--- a/_dev/src/views/campaign-page.vue
+++ b/_dev/src/views/campaign-page.vue
@@ -11,15 +11,15 @@
           <b-skeleton width="70%" />
         </b-card>
       </template>
-
       <campaign-card
+        v-if="$route.name === 'campaign-info'"
         @openPopin="onOpenPopinActivateTracking"
-        v-if="$route.name === 'campaign'"
       />
       <smart-shopping-campaign-table-list
         :loading="loadingCampaignList"
         @loader="changeLoadingState($event)"
         v-else-if="$route.name === 'campaign-list'"
+        :in-need-of-configuration="inNeedOfConfiguration"
       />
       <smart-shopping-campaign-creation
         v-else-if="$route.name === 'campaign-edition' || $route.name === 'campaign-creation'"
@@ -66,6 +66,9 @@ export default {
     };
   },
   computed: {
+    inNeedOfConfiguration() {
+      return !this.googleAdsIsServing;
+    },
     googleAdsIsServing() {
       return this.$store.getters['googleAds/GET_GOOGLE_ADS_ACCOUNT_IS_SERVING'];
     },
@@ -112,15 +115,18 @@ export default {
     },
   },
   mounted() {
-    this.getDatas()
-      .then(() => {
-        this.loadingPage = false;
-        if (this.$route.name === 'campaign' && this.SSCExist) {
-          this.$router.push({
-            name: 'campaign-list',
-          });
-        }
-      });
+    if (!this.inNeedOfConfiguration) {
+      this.getDatas()
+        .then(() => {
+          this.loadingPage = false;
+          if (this.$route.name === 'campaign' && this.SSCExist) {
+            this.$router.push({
+              name: 'campaign-list',
+            });
+          }
+        });
+    }
+    this.loadingPage = false;
   },
   watch: {
     $route: {

--- a/_dev/src/views/campaign-page.vue
+++ b/_dev/src/views/campaign-page.vue
@@ -12,7 +12,7 @@
         </b-card>
       </template>
       <campaign-card
-        v-if="$route.name === 'campaign-info'"
+        v-if="$route.name === 'campaign'"
         @openPopin="onOpenPopinActivateTracking"
       />
       <smart-shopping-campaign-table-list

--- a/_dev/src/views/campaign-page.vue
+++ b/_dev/src/views/campaign-page.vue
@@ -114,12 +114,6 @@ export default {
   mounted() {
     this.getDatas()
       .then(() => {
-        if (!this.googleAdsIsServing) {
-          this.$router.push({
-            name: 'onboarding',
-          });
-        }
-      }).finally(() => {
         this.loadingPage = false;
         if (this.$route.name === 'campaign' && this.SSCExist) {
           this.$router.push({

--- a/_dev/src/views/configuration.vue
+++ b/_dev/src/views/configuration.vue
@@ -1,37 +1,23 @@
 <template>
   <div id="configuration">
     <multistore v-if="!psAccountsIsOnboarded && shops.length" />
-    <landing-page v-else-if="displayLandingPage" />
     <onboarding-page v-else />
   </div>
 </template>
 
 <script>
 import {defineComponent} from '@vue/composition-api';
-import LandingPage from './landing-page.vue';
 import Multistore from './multistore.vue';
 import OnboardingPage from './onboarding-page.vue';
 
 export default defineComponent({
   name: 'configuration',
   components: {
-    LandingPage,
     OnboardingPage,
     Multistore,
   },
-  data() {
-    return {
-      displayLandingPage: true,
-    };
-  },
+
   props: {
-  },
-  created() {
-    this.$root.$on('onHideLanding', () => {
-      this.$router.push({
-        name: 'onboarding',
-      });
-    });
   },
   computed: {
     psAccountsIsOnboarded() {
@@ -40,13 +26,6 @@ export default defineComponent({
     shops() {
       return this.$store.getters['accounts/GET_PS_ACCOUNTS_CONTEXT_SHOPS'];
     },
-  },
-  mounted() {
-    const canDisplayLanding = JSON.parse(localStorage.getItem('canDisplayLanding'));
-
-    if (canDisplayLanding === false) {
-      this.displayLandingPage = false;
-    }
   },
 });
 </script>

--- a/_dev/src/views/landing-page.vue
+++ b/_dev/src/views/landing-page.vue
@@ -1,7 +1,7 @@
 <template>
   <b-card no-body>
     <div class="ps_gs-landingpage">
-      <LandingPageHeader />
+      <LandingPageHeader @hideLandingPage="hideLandingPage" />
       <hr class="my-4">
       <LandingPageContent
         content-image="Merchant-Center-img.png"
@@ -33,7 +33,7 @@
         class="text-muted ps_gs-fz-12 mt-2 mt-md-4 pb-1"
       />
       <hr class="my-4">
-      <LandingPageFooter />
+      <LandingPageFooter @hideLandingPage="hideLandingPage" />
     </div>
   </b-card>
 </template>
@@ -45,6 +45,7 @@ import googleUrl from '@/assets/json/googleUrl.json';
 import LandingPageHeader from '../components/landing-page/landing-page-header';
 import LandingPageContent from '../components/landing-page/landing-page-content';
 import LandingPageFooter from '../components/landing-page/landing-page-footer';
+import SegmentGenericParams from '@/utils/SegmentGenericParams';
 
 export default {
   name: 'LandingPage',
@@ -53,6 +54,18 @@ export default {
     LandingPageHeader,
     LandingPageContent,
     LandingPageFooter,
+  },
+  methods: {
+    hideLandingPage() {
+      this.$router.push({
+        name: 'configuration',
+      });
+      localStorage.setItem('landingHasBeenSeen', true);
+      this.$segment.track('[GGL] Start Configuration', {
+        module: 'psxmarketingwithgoogle',
+        params: SegmentGenericParams,
+      });
+    },
   },
   googleUrl,
 };

--- a/_dev/src/views/multistore.vue
+++ b/_dev/src/views/multistore.vue
@@ -16,7 +16,7 @@ import MultiStoreSelector from '@/components/multistore/multi-store-selector.vue
 import LandingPage from './landing-page.vue';
 
 export default {
-  name: 'OnboardingPage',
+  name: 'Multistore',
   components: {
     MultiStoreSelector,
     LandingPage,

--- a/_dev/src/views/reporting-page.vue
+++ b/_dev/src/views/reporting-page.vue
@@ -36,14 +36,7 @@ export default {
     },
   },
   created() {
-    this.getDatas()
-      .then(() => {
-        if (!this.reportingTabIsActive) {
-          this.$router.push({
-            name: 'onboarding',
-          });
-        }
-      });
+    this.getDatas();
   },
 };
 </script>

--- a/_dev/src/views/reporting-page.vue
+++ b/_dev/src/views/reporting-page.vue
@@ -1,9 +1,11 @@
 <template>
   <div id="reporting-page">
-    <KeyMetricsBlock />
-    <CampaignsPerformanceTable />
-    <ProductsPerformanceTable />
-    <FiltersPerformanceTable />
+    <KeyMetricsBlock :in-need-of-configuration="inNeedOfConfiguration" />
+    <template v-if="!inNeedOfConfiguration">
+      <CampaignsPerformanceTable />
+      <ProductsPerformanceTable />
+      <FiltersPerformanceTable />
+    </template>
   </div>
 </template>
 

--- a/_dev/src/views/reporting-page.vue
+++ b/_dev/src/views/reporting-page.vue
@@ -24,8 +24,12 @@ export default {
     reportingTabIsActive() {
       return this.$store.getters['smartShoppingCampaigns/GET_REPORTING_TAB_IS_ACTIVE'];
     },
+    inNeedOfConfiguration() {
+      return !this.reportingTabIsActive;
+    },
   },
   methods: {
+
     async getDatas() {
       await this.$store.dispatch('smartShoppingCampaigns/SET_REPORTING_DATES_RANGE');
       await this.$store.dispatch('googleAds/GET_GOOGLE_ADS_LIST');
@@ -36,7 +40,9 @@ export default {
     },
   },
   created() {
-    this.getDatas();
+    if (!this.inNeedOfConfiguration) {
+      this.getDatas();
+    }
   },
 };
 </script>

--- a/_dev/src/views/tunnel-product-feed.spec.ts
+++ b/_dev/src/views/tunnel-product-feed.spec.ts
@@ -10,6 +10,7 @@ import {shallowMount} from '@vue/test-utils';
 import Vuex from 'vuex';
 import config, {cloneStore} from '@/../tests/init';
 import TunnelProductFeed from '@/views/tunnel-product-feed.vue';
+
 describe('tunnel-product-feed.vue', () => {
   let actions;
   let store;

--- a/_dev/src/views/tunnel-product-feed.spec.ts
+++ b/_dev/src/views/tunnel-product-feed.spec.ts
@@ -10,7 +10,6 @@ import {shallowMount} from '@vue/test-utils';
 import Vuex from 'vuex';
 import config, {cloneStore} from '@/../tests/init';
 import TunnelProductFeed from '@/views/tunnel-product-feed.vue';
-
 describe('tunnel-product-feed.vue', () => {
   let actions;
   let store;


### PR DESCRIPTION
- landing page and configuration page are now separate
...../landing-page
...../configuration
- tabs are always displayed
- refacto stepper
- product-feed-settings url is on multiple routes : 
step 1  : ....../product-feed-settings/target-country
step 2 : ....../product-feed-settings/shipping-settings
step 3 : ....../product-feed-settings/attribute-mapping
step 4 : ....../product-feed-settings/sync-schedule
step 5 : ....../product-feed-settings/summary
- Screen not configured in case user comes on tabs before configuration finished
![Capture d’écran 2022-02-14 à 10 50 39](https://user-images.githubusercontent.com/37299291/153840614-1202fa7d-0f6a-4b02-aafd-1cbf4665fef4.png)
