### PR TITLE
Fix: add loader displaying while waiting for dimensions in popin filters SSC

### DIFF
--- a/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation-filter-popin/smart-shopping-campaign-creation-popin-dimension.vue
+++ b/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation-filter-popin/smart-shopping-campaign-creation-popin-dimension.vue
@@ -9,7 +9,7 @@
           {{ $t('smartShoppingCampaignCreation.selectProductsSubtitle') }}
         </p>
         <span
-          v-if="!availableDimensions"
+          v-if="!availableDimensions.length"
           class="text-muted"
         >
           <i class="icon-busy icon-busy--dark mr-1" />


### PR DESCRIPTION
Loader was not displaying because condition was not in array length