### PR TITLE
Fix : Change behaviour if user go back in filters

### DIFF
--- a/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation-filter-popin/smart-shopping-campaign-creation-filter-confirm-cancel.vue
+++ b/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation-filter-popin/smart-shopping-campaign-creation-filter-confirm-cancel.vue
@@ -22,7 +22,7 @@
 
 <script>
 import PsModal from '../../commons/ps-modal';
-import {checkAndUpdateDimensionStatus, deepCheckDimension} from '../../../utils/SSCFilters';
+import {findAndCheckFilter} from '../../../utils/SSCFilters';
 
 export default {
   name: 'SSCampaignCreationFilterConfirmCancel',
@@ -39,8 +39,11 @@ export default {
   methods: {
     onAgreed() {
       this.$emit('sendStep', 1);
-      deepCheckDimension(this.$store.state.smartShoppingCampaigns.dimensionChosen, false);
-      checkAndUpdateDimensionStatus(this.$store.state.smartShoppingCampaigns.dimensionChosen);
+      //  Reset filters to what it was previously saved (in store or in edition)
+      findAndCheckFilter(
+        this.$store.state.smartShoppingCampaigns.dimensionChosen,
+        this.$store.state.smartShoppingCampaigns.filtersChosen[0].values,
+      );
     },
   },
 };

--- a/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation-filter-popin/smart-shopping-campaign-creation-popin.vue
+++ b/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation-filter-popin/smart-shopping-campaign-creation-popin.vue
@@ -27,7 +27,6 @@
       ref="SmartShoppingCampaignCreationFilterConfirmCancel"
       :step-is="step"
       @sendStep="stepIs($event)"
-      @updateDimension="sendFiltersSelected"
     />
   </ps-modal>
 </template>

--- a/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation-filter-popin/smart-shopping-campaign-creation-popin.vue
+++ b/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation-filter-popin/smart-shopping-campaign-creation-popin.vue
@@ -27,6 +27,7 @@
       ref="SmartShoppingCampaignCreationFilterConfirmCancel"
       :step-is="step"
       @sendStep="stepIs($event)"
+      @updateDimension="sendFiltersSelected"
     />
   </ps-modal>
 </template>


### PR DESCRIPTION
User chose dimension then chose filters then they save.
STEP 1 : It is now written next to the button 'dimension chosen + number of products affected'

User open back the popin to change filters, check another one, but do not save and click on back button : 

_Previous behaviour_  every checkbox was reset to empty
_Now_ user will go back to STEP 1 with their first selection