### PR TITLE
Define app build version to ease debugging

### DIFF
--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -50,6 +50,7 @@ jobs:
         run: npm run build
         env:
           VUE_APP_CDN_URL: https://storage.googleapis.com/psxmarketing-cdn/${{ steps.get_tag.outputs.MAJOR }}.${{ steps.get_tag.outputs.MINOR }}.${{ steps.get_tag.outputs.PATCH }}/
+          VUE_APP_BUILD_VERSION: ${{ steps.get_tag.outputs.MAJOR }}.${{ steps.get_tag.outputs.MINOR }}.${{ steps.get_tag.outputs.PATCH }}
 
       - name: Build
         working-directory: _dev
@@ -57,6 +58,7 @@ jobs:
         run: npm run build
         env:
           VUE_APP_CDN_URL: https://storage.googleapis.com/psxmarketing-cdn/${{ steps.get_tag.outputs.MAJOR }}.x.x/
+          VUE_APP_BUILD_VERSION: ${{ steps.get_tag.outputs.MAJOR }}.${{ steps.get_tag.outputs.MINOR }}.${{ steps.get_tag.outputs.PATCH }}
 
       - name: Delete old CDN prerelease
         continue-on-error: true

--- a/_dev/src/utils/Sentry.ts
+++ b/_dev/src/utils/Sentry.ts
@@ -2,6 +2,8 @@ import Vue from 'vue';
 import * as Sentry from '@sentry/vue';
 import store from '@/store';
 
+const appVersion = process.env.VUE_APP_BUILD_VERSION || 'dev';
+
 // @ts-ignore
 if (store.state.app.psxMktgWithGoogleOnProductionEnvironment) {
   Sentry.init({
@@ -19,12 +21,13 @@ if (store.state.app.psxMktgWithGoogleOnProductionEnvironment) {
         'prestashop-version': store.state.app.psVersion,
         // @ts-ignore
         'module-version': store.state.app.psxMktgWithGoogleModuleVersion,
+        'app-version': appVersion,
       },
       user: {
         id: window.shopIdPsAccounts ? window.shopIdPsAccounts.toString() : 'unknown',
       },
     },
     // @ts-ignore
-    release: `v${store.state.app.psxMktgWithGoogleModuleVersion}`,
+    release: `v${appVersion}`,
   });
 }

--- a/_dev/src/views/debug.vue
+++ b/_dev/src/views/debug.vue
@@ -39,6 +39,13 @@
             <strong>Prestashop version</strong>: {{ this.$store.state.app.psVersion }}
           </li>
           <li>
+            <strong>Module version</strong>:
+            {{ this.$store.state.app.psxMktgWithGoogleModuleVersion }}
+          </li>
+          <li>
+            <strong>App build version</strong>: {{ appBuildVersion }}
+          </li>
+          <li>
             <strong>Shop ID</strong>: {{ shopId }}
           </li>
           <li>
@@ -213,6 +220,7 @@ export default {
         loading: false,
         error: false,
       },
+      appBuildVersion: process.env.VUE_APP_BUILD_VERSION || 'Not provided',
     };
   },
   components: {


### PR DESCRIPTION
We are currently relying on the PHP version to see on what version an error occured. But with the JS distributed via CDN, the JS version running on the browser is usually different from the module version.
We now set a version at build time, based on the release tag.

Example of debugging data:
![image](https://user-images.githubusercontent.com/6768917/158169122-e4f68688-09a4-4d80-90a6-6a170891b0cd.png)
