### PR TITLE
Implement popin to create first campaign once user is onboarded

### DIFF
--- a/_dev/.storybook/mock/google-ads.js
+++ b/_dev/.storybook/mock/google-ads.js
@@ -79,6 +79,7 @@ export const googleAdsAccountChosen = {
 }
 
 export const adsAccountStatus = {
+  ...googleAdsAccountChosen,
   customer: {
     id: '415-056-4875',
     name: 'Tata Corpette',
@@ -88,8 +89,11 @@ export const adsAccountStatus = {
     isAccountSuspended: false,
     isAccountCancelled: false,
   },
-  billingSettings: {
-    isSet: true,
+  accountChosen:  {
+    ...googleAdsAccountChosen.accountChosen,
+    billingSettings: {
+      isSet: true,
+    }
   },
 }
 

--- a/_dev/src/components/commons/popin-configured.vue
+++ b/_dev/src/components/commons/popin-configured.vue
@@ -1,44 +1,58 @@
 <template>
-  <b-card
-    class="mb-2 shadow-sm border-0"
-    style="max-width: 40rem"
+  <ps-modal
+    id="PopinModuleConfigured"
+    v-bind="$attrs"
+    hide-footer
+    @close="cancel"
+    ref="modal"
   >
-    <b-card-body align="center">
-      <h3 class="font-weight-600">
-        {{ $t("configuredState.title") }}
-      </h3>
+    <b-card
+      style="max-width: 40rem"
+      class="card border-0"
+    >
+      <b-card-body align="center">
+        <h3 class="font-weight-600 text-align-center">
+          {{ $t("configuredState.title") }}
+        </h3>
 
-      <b-img
-        :src="require('@/assets/images/configured.png')"
-        fluid
-      />
-      <VueShowdown :markdown="$t('configuredState.text')" />
-      <template>
-        <ul
-          class="timeline-configured list-unstyled mb-auto"
+        <b-img
+          :src="require('@/assets/images/configured.png')"
+          fluid
+        />
+        <VueShowdown :markdown="$t('configuredState.text')" />
+        <template>
+          <ul
+            class="timeline-configured list-unstyled mb-auto"
+          >
+            <VueShowdown
+              v-for="(oneStep, index) in steps"
+              :key="index"
+              tag="li"
+              :markdown="oneStep"
+              class="timeline-configured__item"
+            />
+          </ul>
+        </template>
+        <b-button
+          class="mt-4"
+          :to="{ name: 'campaign-creation' }"
+          variant="primary"
         >
-          <VueShowdown
-            v-for="(oneStep, index) in steps"
-            :key="index"
-            tag="li"
-            :markdown="oneStep"
-            class="timeline-configured__item"
-          />
-        </ul>
-      </template>
-      <b-button
-        class="mt-4"
-        :to="{ name: 'campaign-creation' }"
-        variant="primary"
-      >
-        {{ $t("configuredState.cta") }}
-      </b-button>
-    </b-card-body>
-  </b-card>
+          {{ $t("configuredState.cta") }}
+        </b-button>
+      </b-card-body>
+    </b-card>
+  </ps-modal>
 </template>
 
 <script>
+import PsModal from './ps-modal.vue';
+
 export default {
+  name: 'PopinModuleConfigured',
+  components: {
+    PsModal,
+  },
   data() {
     return {
       steps: [
@@ -50,6 +64,11 @@ export default {
         this.$i18n.t('configuredState.sixthStep'),
       ],
     };
+  },
+  methods: {
+    cancel() {
+      this.$refs.modal.hide();
+    },
   },
 };
 </script>

--- a/_dev/src/components/google-ads-account/google-ads-account-card.vue
+++ b/_dev/src/components/google-ads-account/google-ads-account-card.vue
@@ -136,7 +136,7 @@
                   size="sm"
                   variant="primary"
                   :disabled="selectedIndex === null"
-                  class="mt-3 mt-md-0 ml-md-3"
+                  class="mt-3 mt-md-0 ml-md-3 flex-shrink-0"
                   @click="selectGoogleAdsAccount"
                 >
                   <template v-if="!isConnecting">

--- a/_dev/src/views/onboarding-page.vue
+++ b/_dev/src/views/onboarding-page.vue
@@ -97,6 +97,9 @@
     <SSCPopinActivateTracking
       ref="SSCPopinActivateTracking"
     />
+    <PopinModuleConfigured
+      ref="PopinModuleConfigured"
+    />
     <!-- Toasts -->
     <PsToast
       v-if="googleAccountConnectedOnce
@@ -137,6 +140,7 @@ import GoogleAdsPopinNew from '../components/google-ads-account/google-ads-accou
 import SmartShoppingCampaignCard from '../components/smart-shopping-campaigns/smart-shopping-campaign-card.vue';
 import SSCPopinActivateTracking from '../components/smart-shopping-campaigns/ssc-popin-activate-tracking.vue';
 import PsToast from '../components/commons/ps-toast';
+import PopinModuleConfigured from '../components/commons/popin-configured.vue';
 import SegmentGenericParams from '@/utils/SegmentGenericParams';
 
 export default {
@@ -158,6 +162,7 @@ export default {
     PsToast,
     FreeListingPopinDisable,
     SSCPopinActivateTracking,
+    PopinModuleConfigured,
   },
   data() {
     return {
@@ -187,6 +192,9 @@ export default {
     },
     onGoogleAdsAccountSelected() {
       this.$store.commit('googleAds/SAVE_GOOGLE_ADS_ACCOUNT_CONNECTED_ONCE', true);
+      this.$bvModal.show(
+        this.$refs.PopinModuleConfigured.$refs.modal.id,
+      );
     },
     onGoogleAccountConnection() {
       this.$store.commit('accounts/SAVE_GOOGLE_ACCOUNT_CONNECTED_ONCE', true);

--- a/_dev/stories/popin-configured.stories.ts
+++ b/_dev/stories/popin-configured.stories.ts
@@ -1,5 +1,11 @@
 import PopinConfigured from '../src/components/commons/popin-configured.vue'
-
+import OnboardingPage from '../src/views/onboarding-page.vue'
+import {contextPsAccountsConnectedAndValidated} from "../.storybook/mock/ps-accounts";
+import {initialStateApp} from "../.storybook/mock/state-app";
+import {googleAccountConnected} from "../.storybook/mock/google-account";
+import {merchantCenterAccountConnected} from "../.storybook/mock/merchant-center-account";
+import {adsAccountStatus} from '../.storybook/mock/google-ads';
+import {productFeedIsConfigured} from '../.storybook/mock/product-feed';
 export default {
   title: 'Basic Components/Popin When Configured',
   component: PopinConfigured,
@@ -7,15 +13,27 @@ export default {
 
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
-  components: { PopinConfigured },
+  components: { PopinConfigured ,OnboardingPage},
   template: `
   <div>
-      <PopinConfigured/>
+  <OnboardingPage />
+      <PopinConfigured ref="PopinModuleConfigured"         :visible="visible"
+      />
       </div>
   `,
+  beforeMount: args.beforeMount,
 });
 
 export const PopinWhenConfigured:any = Template.bind({});
 PopinWhenConfigured.args = {
   visible: true,
+  user: Object.assign({}, googleAccountConnected),
+  beforeMount(this:any){
+    this.$store.state.app = Object.assign({}, initialStateApp);
+    this.$store.state.accounts.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
+    this.$store.state.accounts.googleAccount = Object.assign({}, googleAccountConnected);
+    this.$store.state.accounts.googleMerchantAccount = Object.assign({}, merchantCenterAccountConnected);
+    this.$store.state.productFeed = Object.assign({}, productFeedIsConfigured);
+    this.$store.state.googleAds = Object.assign({}, adsAccountStatus);
+  }
 }

--- a/_dev/stories/popin-configured.stories.ts
+++ b/_dev/stories/popin-configured.stories.ts
@@ -17,7 +17,8 @@ const Template = (args, { argTypes }) => ({
   template: `
   <div>
   <OnboardingPage />
-      <PopinConfigured ref="PopinModuleConfigured"         :visible="visible"
+      <PopinConfigured ref="PopinModuleConfigured"        
+      :visible="visible"
       />
       </div>
   `,


### PR DESCRIPTION
Transform popin in ps-modal, fix storybook and add vuejs dynamisation. 
The popin opens ONLY THE FIRST TIME WHEN google ads account is connected not on refresh of the page if the accounts is already onboarded
![Capture d’écran 2022-03-17 à 11 24 57](https://user-images.githubusercontent.com/37299291/158789369-c00caebc-3c8b-412b-81c3-5ac1217fe567.png)
