### PR TITLE
Fix storybook mock

### DIFF
--- a/_dev/.storybook/mock/product-feed.js
+++ b/_dev/.storybook/mock/product-feed.js
@@ -211,6 +211,7 @@ export const productFeedIsReadyForExport = {
     lastUpdatedAt: null,
     nextJobAt: new Date("July 22, 2021 03:24:00"),
     success: false,
+    syncSchedule: "2021-10-06T01:00:00.000Z",
   },
   settings: {
     ...productFeed.settings,

--- a/_dev/.storybook/mock/smart-shopping-campaigns.js
+++ b/_dev/.storybook/mock/smart-shopping-campaigns.js
@@ -28,6 +28,7 @@ export const availableFilters = [{
       id: "categories",
       checked: false,
       indeterminate: true,
+      visible: true,
       children: [
         {
           status: "ACTIVE",
@@ -35,11 +36,13 @@ export const availableFilters = [{
           name: "Animaux et articles pour animaux de compagnie",
           checked: false,
           indeterminate: true,
+          visible: true,
           children: [
             {
               id:"a",
               name: "Chien",
               checked: true,
+              visible: true,
               indeterminate: false,
               numberOfProductsAssociated: 12,
               children: [
@@ -49,6 +52,7 @@ export const availableFilters = [{
                   languageCode: "fr",
                   name: "Labrador",
                   checked: true,
+                  visible: true,
                   numberOfProductsAssociated: 10,
                 },
                 {
@@ -57,6 +61,7 @@ export const availableFilters = [{
                   languageCode: "fr",
                   name: "Berger Allemand",
                   checked: true,
+                  visible: true,
                   numberOfProductsAssociated: 2,
                 },
               ]
@@ -68,6 +73,7 @@ export const availableFilters = [{
               id: "b",
               name: "Chat",
               checked: true,
+              visible: true,
               indeterminate: false,
             },
           ],
@@ -77,6 +83,7 @@ export const availableFilters = [{
           id: "8",
           name: "Arts et loisirs",
           checked: false,
+          visible: true,
           indeterminate: false,
         },
         {
@@ -85,6 +92,7 @@ export const availableFilters = [{
           name: "Vêtements et accessoires",
           checked: true,
           indeterminate: false,
+          visible: true,
           numberOfProductsAssociated: 13,
           children: [
             {
@@ -92,6 +100,7 @@ export const availableFilters = [{
               id: "111",
               name: "Entreprise et industrie",
               checked: true,
+              visible: true,
               numberOfProductsAssociated: 12,
             },
             {
@@ -99,6 +108,7 @@ export const availableFilters = [{
               id: "141",
               name: "Appareils photo, caméras et instruments d'optique",
               checked: true,
+              visible: true,
               numberOfProductsAssociated: 1,
             },
           ]
@@ -108,6 +118,7 @@ export const availableFilters = [{
           id: "222",
           name: "Appareils électroniques",
           checked: false,
+          visible: true,
           indeterminate: false,
         },
         {
@@ -115,6 +126,7 @@ export const availableFilters = [{
           id: "412",
           name: "Alimentation, boissons et tabac",
           checked: false,
+          visible: true,
           indeterminate: false,
         },
         {
@@ -122,15 +134,17 @@ export const availableFilters = [{
           id: "436",
           name: "Meubles",
           checked: false,
+          visible: true,
           indeterminate: false,
         },
   ],
 },
 {
-  name: "smartShoppingCampaignCreation.brand",
+  name: "Brand",
   id: "brand",
   checked: false,
   indeterminate: true,
+  visible: true,
   children: [
     {
       status: "ACTIVE",
@@ -140,24 +154,28 @@ export const availableFilters = [{
       name: "Animaux et articles pour animaux de compagnie",
       checked: false,
       indeterminate: true,
+      visible: true,
       children: [
         {
           id:"a",
           name: "Chien",
           checked: true,
           indeterminate: false,
+          visible: true,
           numberOfProductsAssociated: 12,
           children: [
             {
               id:"ab",
               name: "Labrador",
               checked: true,
+              visible: true,
               numberOfProductsAssociated: 10,
             },
             {
               id:"abc",
               name: "Berger Allemand",
               checked: true,
+              visible: true,
               numberOfProductsAssociated: 2,
             },
           ]
@@ -169,6 +187,7 @@ export const availableFilters = [{
           id: "b",
           name: "Chat",
           checked: true,
+          visible: true,
           indeterminate: false,
         },
       ],
@@ -180,6 +199,7 @@ export const availableFilters = [{
       languageCode: "fr",
       name: "Arts et loisirs",
       checked: false,
+      visible: true,
       indeterminate: false,
     },
     {
@@ -189,6 +209,7 @@ export const availableFilters = [{
       languageCode: "fr",
       name: "Vêtements et accessoires",
       checked: true,
+      visible: true,
       indeterminate: false,
       numberOfProductsAssociated: 24,
       children: [
@@ -197,6 +218,7 @@ export const availableFilters = [{
           id: "111",
           name: "Entreprise et industrie",
           checked: true,
+          visible: true,
           numberOfProductsAssociated: 12,
         },
         {
@@ -204,6 +226,7 @@ export const availableFilters = [{
           id: "141",
           name: "Appareils photo, caméras et instruments d'optique",
           checked: true,
+          visible: true,
           numberOfProductsAssociated: 12,
         },
       ]
@@ -215,6 +238,7 @@ export const availableFilters = [{
       languageCode: "fr",
       name: "Appareils électroniques",
       checked: false,
+      visible: true,
       indeterminate: false,
     },
     {
@@ -224,6 +248,7 @@ export const availableFilters = [{
       languageCode: "fr",
       name: "Alimentation, boissons et tabac",
       checked: false,
+      visible: true,
       indeterminate: false,
     },
     {
@@ -233,6 +258,7 @@ export const availableFilters = [{
       languageCode: "fr",
       name: "Meubles",
       checked: false,
+      visible: true,
       indeterminate: false,
     },
 ],

--- a/_dev/.storybook/mock/smart-shopping-campaigns.js
+++ b/_dev/.storybook/mock/smart-shopping-campaigns.js
@@ -266,19 +266,21 @@ export const availableFilters = [{
 
 export const campaignWithUnhandledFilters = {
   campaignName: 'A super name',
-  campaignDurationStartDate: '2021-10-30',
-  campaignDurationEndDate: '2021-12-30',
-  campaignProductsFilter: [],
+  startDate: '2021-10-30',
+  endDate: '2021-12-30',
+  productFilters: [],
   campaignDailyBudget: 7,
-  campaignIsActive: true,
-  campaignId: 'foo',
+  dailyBudget: true,
+  id: 'foo',
   targetCountry: 'France',
   campaignHasNoProductsFilter: false,
   hasUnhandledFilters: true,
 };
+
 export const campaignWithoutUnhandledFilters = {
  ...campaignWithUnhandledFilters,
   hasUnhandledFilters: false,
 };
+
 
 export default sscDefault;

--- a/_dev/src/components/product-feed/settings/summary/summary.spec.ts
+++ b/_dev/src/components/product-feed/settings/summary/summary.spec.ts
@@ -9,14 +9,35 @@ import {cloneStore, filters, localVue} from '@/../tests/init';
 import ProductFeedSettingsSummary from '@/components/product-feed/settings/summary/summary.vue';
 import ProductFeedCardNextSyncCard from '@/components/product-feed/product-feed-card-next-sync-card.vue';
 import ActionsButtons from '@/components/product-feed/settings/commons/actions-buttons.vue';
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
 
 import {
   Summary,
 } from '@/../stories/product-feed-settings.stories';
 
 describe('summary', () => {
+  const mockRoute = {
+    name: 'product-feed-settings',
+    params: {
+      step: ProductFeedSettingsPages.SUMMARY,
+    },
+  };
+  const mockRouter = {
+    history: {
+      current : {
+        params: {
+          step: ProductFeedSettingsPages.SUMMARY,
+        },
+      }
+    },
+    push: jest.fn(),
+  };
   it('shows datas', () => {
     const wrapper = shallowMount(ProductFeedSettingsSummary, {
+      mocks: {
+        $route: mockRoute,
+        $router: mockRouter,
+      },
       propsData: Summary.args,
       beforeMount: Summary.args.beforeMount,
       localVue,
@@ -28,6 +49,10 @@ describe('summary', () => {
   });
   it('shows button cancel and triggers previous step on click', async () => {
     const wrapper = shallowMount(ProductFeedSettingsSummary, {
+      mocks: {
+        $route: mockRoute,
+        $router: mockRouter,
+      },
       propsData: Summary.args,
       beforeMount: Summary.args.beforeMount,
       localVue,

--- a/_dev/src/components/product-feed/settings/summary/summary.spec.ts
+++ b/_dev/src/components/product-feed/settings/summary/summary.spec.ts
@@ -24,11 +24,11 @@ describe('summary', () => {
   };
   const mockRouter = {
     history: {
-      current : {
+      current: {
         params: {
           step: ProductFeedSettingsPages.SUMMARY,
         },
-      }
+      },
     },
     push: jest.fn(),
   };

--- a/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation.vue
+++ b/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation.vue
@@ -280,7 +280,9 @@
                   {{ $t("cta.selectFilters") }}
                 </b-button>
                 <div
-                  v-if="!campaignHasNoProductsFilter && filtersChosen.length"
+                  v-if="!campaignHasNoProductsFilter
+                    && filtersChosen.length
+                    && !hasUnhandledFilters"
                   class="align-self-center ml-2 font-weight-600"
                 >
                   {{ $tc(

--- a/_dev/stories/product-feed-settings.stories.ts
+++ b/_dev/stories/product-feed-settings.stories.ts
@@ -2,6 +2,7 @@ import TunnelProductFeed from '../src/views/tunnel-product-feed.vue';
 import {productFeed, productFeedNoCarriers ,productFeedIsReadyForExport, productFeedSyncScheduleNow} from '../.storybook/mock/product-feed';
 import {initialStateApp, appMultiCountries} from '../.storybook/mock/state-app';
 import {rest} from 'msw';
+import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
 
 export default {
   title: 'Product feed/Settings',
@@ -97,6 +98,7 @@ TargetCountry.args = {
     this.$store.state.productFeed = Object.assign({},productFeed);
     this.$store.state.app = Object.assign({},initialStateApp);
     this.$store.state.productFeed.stepper = 1;
+      this.$router.history.current.params.step = ProductFeedSettingsPages.TARGET_COUNTRY
   },
 };
 
@@ -105,6 +107,7 @@ ShippingSettings.args = {
   beforeMount(this: any) {
     this.$store.state.productFeed = Object.assign({},productFeed);
     this.$store.state.productFeed.stepper = 2;
+    this.$router.history.current.params.step = ProductFeedSettingsPages.SHIPPING_SETTINGS
   },
 };
 
@@ -114,6 +117,7 @@ ShippingSettingsNoCarriers.args = {
   beforeMount(this: any) {
     this.$store.state.productFeed = Object.assign({},productFeedNoCarriers);
     this.$store.state.productFeed.stepper = 2;
+    this.$router.history.current.params.step = ProductFeedSettingsPages.SHIPPING_SETTINGS
   },
 };
 
@@ -122,6 +126,7 @@ AttributeMapping.args = {
   beforeMount(this: any) {
     this.$store.state.productFeed = Object.assign({},productFeed);
     this.$store.state.productFeed.stepper = 3;
+    this.$router.history.current.params.step = ProductFeedSettingsPages.ATTRIBUTE_MAPPING
   },
 };
 
@@ -130,6 +135,7 @@ SyncSchedule.args = {
   beforeMount(this: any) {
     this.$store.state.productFeed = Object.assign({},productFeedSyncScheduleNow);
     this.$store.state.productFeed.stepper = 4;
+    this.$router.history.current.params.step = ProductFeedSettingsPages.SYNC_SCHEDULE
   },
 };
 
@@ -138,5 +144,6 @@ Summary.args = {
   beforeMount(this: any) {
     this.$store.state.productFeed = Object.assign({},productFeedIsReadyForExport);
     this.$store.state.productFeed.stepper = 5;
+    this.$router.history.current.params.step = ProductFeedSettingsPages.SUMMARY
   },
 };

--- a/_dev/stories/smart-shopping-campaign-creation.stories.ts
+++ b/_dev/stories/smart-shopping-campaign-creation.stories.ts
@@ -323,6 +323,8 @@ EditionWithUnhandledFilters.parameters = {
 
 export const ErrorRetrievingFilters: any = Template.bind({});
 ErrorRetrievingFilters.args = {
+  loader: false,
+  searchLoader: false,
   mounted(this: any) {
     this.$store.state.productFeed.validationSummary.activeItems = 2;
     // Is empty but is filled right away??
@@ -344,6 +346,7 @@ export const PopinFiltersDimensionStep: any = Template.bind({});
 PopinFiltersDimensionStep.args = {
   visible: true,
   loader: false,
+  searchLoader: false,
   beforeMount(this: any) {
     this.$store.state.smartShoppingCampaigns.errorCampaignNameExists = null;
   },

--- a/_dev/stories/smart-shopping-campaign-creation.stories.ts
+++ b/_dev/stories/smart-shopping-campaign-creation.stories.ts
@@ -277,52 +277,55 @@ EditionWithUnhandledFilters.args = {
 },
 };
 EditionWithUnhandledFilters.parameters = {
-  msw: {
-    handlers: [
-      rest.get("/shopping-campaigns/list",  (req, res, ctx) => {
-        return res(ctx.json({"campaigns":[
-          {
-              "id": "16004060865",
-              "resourceName": "customers/4088436776/campaigns/16004060865",
-              "campaignName": "rgereegr",
-              "startDate": "2022-01-27",
-              "endDate": "2037-12-30",
-              "targetCountry": "FR",
-              "dailyBudget": 3,
-              "status": "ELIGIBLE",
-              "currencyCode": "EUR",
-              "productFilters": [
-                  {
-                      "dimension": "categories",
-                      "values": [
-                          "2169"
-                      ]
-                  }
-              ],
-              "hasUnhandledFilters": true
-          },
-          {
-              "id": "16004011605",
-              "resourceName": "customers/4088436776/campaigns/16004011605",
-              "campaignName": "zret",
-              "startDate": "2022-01-27",
-              "endDate": "2037-12-30",
-              "targetCountry": "FR",
-              "dailyBudget": 1,
-              "status": "ELIGIBLE",
-              "currencyCode": "EUR",
-              "productFilters": [
-                  {
-                      "dimension": "categories",
-                      "values": [
-                          "2169",
-                          "502981"
-                      ]
-                  }
-              ],
-              "hasUnhandledFilters": false
-          }
-      ]}))}),
+    msw: {
+      handlers: [
+        rest.get("/shopping-campaigns/list",  (req, res, ctx) => {
+          return res(ctx.json({"campaigns":[
+            {
+                "id": "16004060865",
+                "resourceName": "customers/4088436776/campaigns/16004060865",
+                "campaignName": "rgereegr",
+                "startDate": "2022-01-27",
+                "endDate": "2037-12-30",
+                "targetCountry": "FR",
+                "dailyBudget": 3,
+                "status": "ELIGIBLE",
+                "currencyCode": "EUR",
+                "productFilters": [
+                    {
+                        "dimension": "categories",
+                        "values": [
+                            "2169"
+                        ]
+                    }
+                ],
+                "hasUnhandledFilters": true
+            },
+            {
+                "id": "16004011605",
+                "resourceName": "customers/4088436776/campaigns/16004011605",
+                "campaignName": "zret",
+                "startDate": "2022-01-27",
+                "endDate": "2037-12-30",
+                "targetCountry": "FR",
+                "dailyBudget": 1,
+                "status": "ELIGIBLE",
+                "currencyCode": "EUR",
+                "productFilters": [
+                    {
+                        "dimension": "categories",
+                        "values": [
+                            "2169",
+                            "502981"
+                        ]
+                    }
+                ],
+                "hasUnhandledFilters": false
+              },
+            ],
+          })
+        );
+      }),
     ],
   },
 };

--- a/_dev/stories/smart-shopping-campaign-creation.stories.ts
+++ b/_dev/stories/smart-shopping-campaign-creation.stories.ts
@@ -210,6 +210,8 @@ const Template = (args, { argTypes }) => ({
 
 export const Creation: any = Template.bind({});
 Creation.args = {
+  loader: false,
+  searchLoader: false,
   beforeMount(this: any) {
     this.$store.state.smartShoppingCampaigns.errorCampaignNameExists = null;
     this.$store.state.productFeed.validationSummary.activeItems = 2;
@@ -218,6 +220,8 @@ Creation.args = {
 
 export const CreationWithoutProducts: any = Template.bind({});
 CreationWithoutProducts.args = {
+  loader: false,
+  searchLoader: false,
   beforeMount(this: any) {
     this.$store.state.smartShoppingCampaigns.errorCampaignNameExists = null;
     this.$store.state.productFeed.validationSummary.activeItems = 0;
@@ -226,6 +230,8 @@ CreationWithoutProducts.args = {
 
 export const FieldsErrorFeedback: any = Template.bind({});
 FieldsErrorFeedback.args = {
+  loader: false,
+  searchLoader: false,
   mounted(this: any) {
     // set name
     this.$refs.sscCreation.$data.campaignName = "foobar";
@@ -362,6 +368,7 @@ PopinFiltersFiltersStep.args = {
   step: 2,
   visible: true,
   loader: false,
+  searchLoader: false,
   beforeMount(this: any) {
     this.$store.state.smartShoppingCampaigns.errorCampaignNameExists = null;
   },

--- a/_dev/stories/smart-shopping-campaign-creation.stories.ts
+++ b/_dev/stories/smart-shopping-campaign-creation.stories.ts
@@ -2,7 +2,7 @@ import SmartShoppingCampaignCreation from "../src/components/smart-shopping-camp
 import SmartShoppingCampaignPopin from "../src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation-filter-popin/smart-shopping-campaign-creation-popin.vue"
 import { initialStateApp } from "../.storybook/mock/state-app";
 import { googleAdsAccountChosen } from "../.storybook/mock/google-ads.js";
-import { campaignWithUnhandledFilters } from "../.storybook/mock/smart-shopping-campaigns";
+import { campaignWithUnhandledFilters, campaignBasic } from "../.storybook/mock/smart-shopping-campaigns";
 import { rest } from "msw";
 import { availableFilters } from "../.storybook/mock/smart-shopping-campaigns.js";
 
@@ -245,28 +245,79 @@ FieldsErrorFeedback.args = {
 export const Edition: any = Template.bind({});
 Edition.args = {
   editMode: true,
+  loader: false,
+  searchLoader: false,
   mounted(this: any) {
+    this.$router.history.current.params.id = '16004060865'
+    this.$store.state.smartShoppingCampaigns.filtersChosen = [{dimension: 'bla', values: ['1', '2']}]
     this.$store.state.productFeed.validationSummary.activeItems = 2;
-    this.$refs.sscCreation.$data.campaignName = "A super name";
-    this.$refs.sscCreation.$data.campaignDurationStartDate = "2021-10-30";
-    this.$refs.sscCreation.$data.campaignDurationEndDate = "2021-12-30";
-    this.$refs.sscCreation.$data.campaignProductsFilter = [];
-    this.$refs.sscCreation.$data.campaignDailyBudget = 7;
-    this.$refs.sscCreation.$data.campaignIsActive = true;
-    this.$refs.sscCreation.$data.campaignId = "foo";
-    this.$refs.sscCreation.$data.targetCountry = "France"
   },
 };
 
 export const EditionWithUnhandledFilters: any = Template.bind({});
 EditionWithUnhandledFilters.args = {
   editMode: true,
+  loader: false,
+  searchLoader: false,
   mounted(this: any) {
+    this.$store.state.smartShoppingCampaigns.campaigns= Object.assign([], [campaignWithUnhandledFilters]);
+    this.$router.history.current.params.id = '16004060865',
+    this.$store.state.smartShoppingCampaigns.errorFetchingFilters = false;
     this.$store.state.productFeed.validationSummary.activeItems = 2;
     Object.assign(
       this.$refs.sscCreation.$data,
       campaignWithUnhandledFilters
     );
+},
+};
+EditionWithUnhandledFilters.parameters = {
+  msw: {
+    handlers: [
+      rest.get("/shopping-campaigns/list",  (req, res, ctx) => {
+        return res(ctx.json({"campaigns":[
+          {
+              "id": "16004060865",
+              "resourceName": "customers/4088436776/campaigns/16004060865",
+              "campaignName": "rgereegr",
+              "startDate": "2022-01-27",
+              "endDate": "2037-12-30",
+              "targetCountry": "FR",
+              "dailyBudget": 3,
+              "status": "ELIGIBLE",
+              "currencyCode": "EUR",
+              "productFilters": [
+                  {
+                      "dimension": "categories",
+                      "values": [
+                          "2169"
+                      ]
+                  }
+              ],
+              "hasUnhandledFilters": true
+          },
+          {
+              "id": "16004011605",
+              "resourceName": "customers/4088436776/campaigns/16004011605",
+              "campaignName": "zret",
+              "startDate": "2022-01-27",
+              "endDate": "2037-12-30",
+              "targetCountry": "FR",
+              "dailyBudget": 1,
+              "status": "ELIGIBLE",
+              "currencyCode": "EUR",
+              "productFilters": [
+                  {
+                      "dimension": "categories",
+                      "values": [
+                          "2169",
+                          "502981"
+                      ]
+                  }
+              ],
+              "hasUnhandledFilters": false
+          }
+      ]}))}),
+    ],
   },
 };
 


### PR DESCRIPTION
Add property "visible" to be on the same page as API data

Add loader props on stories

Add router params in product-feed-settings and mock it for the tests for the stories

Modify mock MSW to retrieve campaigns in stories smart shopping campaign edition 

Add `syncSchedule` in the right data in product feed stories