### PR TITLE
Fix : CSS + unsolicited toast display + remarketing tag popin after click on banner

### DIFF
--- a/_dev/src/components/commons/banner-campaigns.vue
+++ b/_dev/src/components/commons/banner-campaigns.vue
@@ -20,9 +20,8 @@
 
         <b-button
           class="flex-shrink-0"
-          :to="{name: 'campaign-creation'}"
           variant="primary"
-          @click="segmentEvent"
+          @click="openPopinActivateTracking"
         >
           {{ $t('banner.ctaCreateFirstCampaign') }}
         </b-button>
@@ -45,13 +44,24 @@ export default {
     pngBanner() {
       return searchImage(this.$store.state.app.psxMktgWithGoogleShopCurrency.isoCode);
     },
+    SSCExist() {
+      return !!this.$store.getters['smartShoppingCampaigns/GET_ALL_SSC']?.length;
+    },
   },
   methods: {
-    segmentEvent() {
+    openPopinActivateTracking() {
       this.$segment.track('[GGL] Click on Create your first campaign - Campaign tab', {
         module: 'psxmarketingwithgoogle',
         params: SegmentGenericParams,
       });
+      // Prevent popin for opening if tracking is a campaign exists
+      if (this.SSCExist) {
+        this.$router.push({
+          name: 'campaign-creation',
+        });
+      } else {
+        this.$emit('openPopinRemarketingTag');
+      }
     },
   },
 };

--- a/_dev/src/components/commons/select-country.vue
+++ b/_dev/src/components/commons/select-country.vue
@@ -2,13 +2,13 @@
   <div>
     <ps-select
       :deselect-from-dropdown="true"
-      :multiple="isMultiple"
+      :multiple="true"
       :options="dropdownOptions"
       @search="onSearchCountry"
       label="name"
       v-model="countries"
       :placeholder=" $t('productFeedSettings.shipping.placeholderSelect')"
-      class="maxw-sm-500"
+      :class="{'maxw-sm-500': notFullWidth }"
     >
       <template v-slot:option="option">
         <div class="d-flex flex-wrap flex-md-nowrap align-items-center pr-3">
@@ -62,12 +62,12 @@ export default {
       type: Array,
       required: true,
     },
-    isMultiple: {
+    needFilter: {
       type: Boolean,
       required: false,
-      default: true,
+      default: false,
     },
-    needFilter: {
+    notFullWidth: {
       type: Boolean,
       required: false,
       default: false,

--- a/_dev/src/components/google-ads-account/google-ads-account-popin-new.vue
+++ b/_dev/src/components/google-ads-account/google-ads-account-popin-new.vue
@@ -68,7 +68,6 @@
         <SelectCountry
           @countrySelected="saveCountrySelected"
           :default-value="defaultCountry()"
-          :is-multiple="false"
           :need-filter="true"
           :dropdown-options="activeCountriesWithCurrency"
         />

--- a/_dev/src/components/product-feed/settings/target-countries/target-countries.vue
+++ b/_dev/src/components/product-feed/settings/target-countries/target-countries.vue
@@ -12,7 +12,7 @@
         :default-value="countries"
         :dropdown-options="activeCountriesWithCurrency"
         :need-filter="true"
-        :is-multiple="true"
+        :not-full-width="true"
       />
     </b-form-group>
     <b-form-group

--- a/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation.vue
+++ b/_dev/src/components/smart-shopping-campaign-creation/smart-shopping-campaign-creation.vue
@@ -218,7 +218,6 @@
                 @countrySelected="saveCountrySelected"
                 :default-value="defaultCountry()"
                 :need-filter="false"
-                :is-multiple="false"
                 :dropdown-options="activeCountries"
               />
               <span v-else>

--- a/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list.vue
+++ b/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <BannerCampaigns v-if="!campaignList.length && !inNeedOfConfiguration" />
+    <BannerCampaigns
+      v-if="!campaignList.length && !inNeedOfConfiguration"
+      @openPopinRemarketingTag="remarketingTagPopin"
+    />
     <h3 class="order-2 order-md-1 ps_gs-fz-20 font-weight-600">
       {{ $t('smartShoppingCampaignList.tableTitle') }}
     </h3>
@@ -145,6 +148,10 @@
         </b-tbody>
       </b-table-simple>
     </div>
+    <SSCPopinActivateTracking
+      modal-id="SSCPopinActivateTrackingSSCList"
+      ref="SSCPopinActivateTrackingSSCList"
+    />
   </div>
 </template>
 
@@ -156,6 +163,7 @@ import QueryOrderDirection from '@/enums/reporting/QueryOrderDirection';
 import googleUrl from '../../assets/json/googleUrl.json';
 import NotConfiguredCard from '@/components/commons/not-configured-card.vue';
 import BannerCampaigns from '@/components/commons/banner-campaigns.vue';
+import SSCPopinActivateTracking from '@/components/smart-shopping-campaigns/ssc-popin-activate-tracking.vue';
 
 export default {
   name: 'SmartShoppingCampaignTableList',
@@ -164,6 +172,7 @@ export default {
     ReportingTableHeader,
     NotConfiguredCard,
     BannerCampaigns,
+    SSCPopinActivateTracking,
   },
   data() {
     return {
@@ -293,6 +302,11 @@ export default {
       ) {
         this.fetchCampaigns(false);
       }
+    },
+    remarketingTagPopin() {
+      this.$bvModal.show(
+        this.$refs.SSCPopinActivateTrackingSSCList.$refs.modal.id,
+      );
     },
   },
   mounted() {

--- a/_dev/src/components/smart-shopping-campaigns/ssc-popin-activate-tracking.vue
+++ b/_dev/src/components/smart-shopping-campaigns/ssc-popin-activate-tracking.vue
@@ -1,6 +1,6 @@
 <template>
   <ps-modal
-    id="SSCPopinActivateTracking"
+    :id="modalId"
     ref="modal"
     :title="$t('modal.titleActivateTrackingSSC')"
     v-bind="$attrs"
@@ -92,6 +92,13 @@ export default {
   name: 'SSCPopinActivateTracking',
   components: {
     PsModal,
+  },
+  props: {
+    modalId: {
+      type: String,
+      required: true,
+      default: null,
+    },
   },
   data() {
     return {

--- a/_dev/src/views/campaign-page.vue
+++ b/_dev/src/views/campaign-page.vue
@@ -28,7 +28,8 @@
       />
     </b-skeleton-wrapper>
     <SSCPopinActivateTracking
-      ref="SSCPopinActivateTracking"
+      ref="SSCPopinActivateTrackingCampaignPage"
+      modal-id="SSCPopinActivateTrackingCampaignPage"
     />
     <PsToast
       v-if="campaignCreated"
@@ -99,7 +100,7 @@ export default {
     },
     onOpenPopinActivateTracking() {
       this.$bvModal.show(
-        this.$refs.SSCPopinActivateTracking.$refs.modal.id,
+        this.$refs.SSCPopinActivateTrackingCampaignPage.$refs.modal.id,
       );
     },
     onCampaignHasBeenCreated() {

--- a/_dev/src/views/onboarding-page.vue
+++ b/_dev/src/views/onboarding-page.vue
@@ -95,7 +95,8 @@
       @cancelGoogleAdsCreationNewAccount="onGoogleAdsAccountTogglePopin"
     />
     <SSCPopinActivateTracking
-      ref="SSCPopinActivateTracking"
+      ref="SSCPopinActivateTrackingOnboardingPage"
+      modal-id="SSCPopinActivateTrackingOnboardingPage"
     />
     <PopinModuleConfigured
       ref="PopinModuleConfigured"
@@ -227,7 +228,7 @@ export default {
     },
     onOpenPopinActivateTracking() {
       this.$bvModal.show(
-        this.$refs.SSCPopinActivateTracking.$refs.modal.id,
+        this.$refs.SSCPopinActivateTrackingOnboardingPage.$refs.modal.id,
       );
     },
     toastIsClosed() {

--- a/_dev/src/views/product-feed-page.vue
+++ b/_dev/src/views/product-feed-page.vue
@@ -6,9 +6,9 @@
     />
     <template v-else>
       <PsToast
-        v-if="syncStatus === 'schedule'"
-        variant="schedule"
-        :visible="syncStatus === 'schedule'"
+        v-if="syncStatus === 'schedule' && !inNeedOfConfiguration"
+        variant="warning"
+        :visible="syncStatus === 'schedule' && !inNeedOfConfiguration"
         toaster="b-toaster-top-right"
       >
         <p> {{ $t('productFeedPage.alert.alertSuccess') }}</p>


### PR DESCRIPTION
- Toast should not be displayed on empty state export status tab
- Target country selector : remove the icon cross (remove props isMultiple because the selector already save only one country)
- Creation campaign on banner; button should have same behaviour than the other create campaign (differenciate all ids and refs from modal to prevent them for opening twice)
- CSS : title spacing in popin module configured
