### PR TITLE
Campaign performances table : replace button because no link available yet

### DIFF
--- a/_dev/src/components/smart-shopping-campaign/reporting/campaigns-performance/campaigns-performance-table-row.vue
+++ b/_dev/src/components/smart-shopping-campaign/reporting/campaigns-performance/campaigns-performance-table-row.vue
@@ -3,21 +3,20 @@
     <b-td
       class="b-table-sticky-column text-primary"
     >
-      <div
-        class="p-0 m-0 font-weight-normal ps_gs-fz-12"
-      >
-        {{ campaign.name }}
-      </div>
-
-      <!--
-      TODO : when API sends back ID of campaign we will be able to make a link
-        <b-button
+      <b-button
+        v-if="campaign.id"
         variant="link"
         @click="goToCampaignPage"
         class="p-0 m-0 font-weight-normal ps_gs-fz-12"
       >
         {{ campaign.name }}
-      </b-button> -->
+      </b-button>
+      <div
+        v-else
+        class="p-0 m-0 font-weight-normal ps_gs-fz-12"
+      >
+        {{ campaign.name }}
+      </div>
     </b-td>
     <b-td
       class="ps_gs-fz-12 ps_gs-cell-status"
@@ -61,15 +60,14 @@ export default {
     },
   },
   methods: {
-    // TODO : when API sends back ID of campaign we will be able to make a link
-    // goToCampaignPage() {
-    //   this.$router.push({
-    //     name: 'campaign-edition',
-    //     params: {
-    //       id: this.campaign.id,
-    //     },
-    //   });
-    // },
+    goToCampaignPage() {
+      this.$router.push({
+        name: 'campaign-edition',
+        params: {
+          id: this.campaign.id,
+        },
+      });
+    },
   },
 };
 </script>

--- a/_dev/src/components/smart-shopping-campaign/reporting/campaigns-performance/campaigns-performance-table-row.vue
+++ b/_dev/src/components/smart-shopping-campaign/reporting/campaigns-performance/campaigns-performance-table-row.vue
@@ -3,13 +3,21 @@
     <b-td
       class="b-table-sticky-column text-primary"
     >
-      <b-button
+      <div
+        class="p-0 m-0 font-weight-normal ps_gs-fz-12"
+      >
+        {{ campaign.name }}
+      </div>
+
+      <!--
+      TODO : when API sends back ID of campaign we will be able to make a link
+        <b-button
         variant="link"
         @click="goToCampaignPage"
         class="p-0 m-0 font-weight-normal ps_gs-fz-12"
       >
         {{ campaign.name }}
-      </b-button>
+      </b-button> -->
     </b-td>
     <b-td
       class="ps_gs-fz-12 ps_gs-cell-status"
@@ -53,14 +61,15 @@ export default {
     },
   },
   methods: {
-    goToCampaignPage() {
-      this.$router.push({
-        name: 'campaign-edition',
-        params: {
-          id: this.campaign.id,
-        },
-      });
-    },
+    // TODO : when API sends back ID of campaign we will be able to make a link
+    // goToCampaignPage() {
+    //   this.$router.push({
+    //     name: 'campaign-edition',
+    //     params: {
+    //       id: this.campaign.id,
+    //     },
+    //   });
+    // },
   },
 };
 </script>

--- a/_dev/src/components/smart-shopping-campaign/reporting/campaigns-performance/campaigns-performance-table-row.vue
+++ b/_dev/src/components/smart-shopping-campaign/reporting/campaigns-performance/campaigns-performance-table-row.vue
@@ -5,6 +5,7 @@
     >
       <b-button
         variant="link"
+        @click="goToCampaignPage"
         class="p-0 m-0 font-weight-normal ps_gs-fz-12"
       >
         {{ campaign.name }}
@@ -49,6 +50,16 @@ export default {
   computed: {
     currencyCode() {
       return this.$store.getters['googleAds/GET_GOOGLE_ADS_ACCOUNT_CHOSEN']?.currencyCode;
+    },
+  },
+  methods: {
+    goToCampaignPage() {
+      this.$router.push({
+        name: 'campaign-edition',
+        params: {
+          id: this.campaign.id,
+        },
+      });
     },
   },
 };


### PR DESCRIPTION
 API needs to send ID in /ads-reporting/campaigns-performances but it's not doable at the moment