### PR TITLE
Use PHP session storage when available

### DIFF
--- a/classes/Buffer/TemplateBuffer.php
+++ b/classes/Buffer/TemplateBuffer.php
@@ -31,7 +31,13 @@ class TemplateBuffer
 
     public function init()
     {
-        $this->session = new Session();
+        if (class_exists('Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage')) {
+            $this->session = new Session(
+                new \Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage()
+            );
+        } else {
+            $this->session = new Session();
+        }
         $this->session->start();
     }
 


### PR DESCRIPTION
There is almost no Symfony on the Front office. When Session is started by PHP, the module makes the FO crash.
This PR should prevent the following error to happen:

![image](https://user-images.githubusercontent.com/6768917/164220512-377bc279-c3b7-4f46-8bc4-15c29b50b6c2.png)
