### PR TITLE
Fix an issue preventing the front office to be displayed in some cases when the module is enabled + Other improvements of conversion actions

### DIFF
--- a/classes/Buffer/TemplateBuffer.php
+++ b/classes/Buffer/TemplateBuffer.php
@@ -21,6 +21,7 @@
 namespace PrestaShop\Module\PsxMarketingWithGoogle\Buffer;
 
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 
 class TemplateBuffer
 {
@@ -29,10 +30,17 @@ class TemplateBuffer
      */
     private $session;
 
-    public function init()
+    public function init($userId)
     {
-        $this->session = new Session();
+        $this->session = new Session(
+            new MockFileSessionStorage(
+                \_PS_CACHE_DIR_ . '/psxmarketingwithgoogle_sessions',
+                'conversionaction'
+            )
+        );
+        $this->session->setId($userId);
         $this->session->start();
+        register_shutdown_function([$this, 'save']);
     }
 
     /**
@@ -60,5 +68,10 @@ class TemplateBuffer
         }
 
         return $data;
+    }
+
+    public function save(): void
+    {
+        $this->session->save();
     }
 }

--- a/classes/Handler/RemarketingHookHandler.php
+++ b/classes/Handler/RemarketingHookHandler.php
@@ -76,7 +76,7 @@ class RemarketingHookHandler
             ?: [];
 
         if ($this->active) {
-            $this->templateBuffer->init();
+            $this->templateBuffer->init($context->customer->id_guest);
         }
     }
 

--- a/classes/Provider/CartEventDataProvider.php
+++ b/classes/Provider/CartEventDataProvider.php
@@ -47,6 +47,6 @@ class CartEventDataProvider
         return (new ConversionEventData())
             ->setSendTo($sendTo)
             ->setCurrency($this->context->currency->iso_code)
-            ->setValue(\Product::getPriceStatic($product->id, true, $idProductAttribute, 2));
+            ->setValue((string) \Product::getPriceStatic($product->id, true, $idProductAttribute, 2));
     }
 }

--- a/classes/Provider/CartEventDataProvider.php
+++ b/classes/Provider/CartEventDataProvider.php
@@ -42,10 +42,11 @@ class CartEventDataProvider
     public function getEventData($sendTo, $data): ConversionEventData
     {
         $product = $data['product'];
+        $idProductAttribute = isset($data['id_product_attribute']) ? $data['id_product_attribute'] : 0;
 
         return (new ConversionEventData())
             ->setSendTo($sendTo)
             ->setCurrency($this->context->currency->iso_code)
-            ->setValue($product->price);
+            ->setValue(\Product::getPriceStatic($product->id, true, $idProductAttribute, 2));
     }
 }

--- a/classes/Provider/ProductDataProvider.php
+++ b/classes/Provider/ProductDataProvider.php
@@ -44,7 +44,6 @@ class ProductDataProvider
             [
                 (int) $product['id_product'],
                 (int) $product['id_product_attribute'],
-                $this->context->language->iso_code,
             ]
         ));
         $productData->setPrice((float) $product['product_price_wt']);
@@ -63,7 +62,6 @@ class ProductDataProvider
             [
                 (int) $product->id,
                 (int) $params['id_product_attribute'],
-                $this->context->language->iso_code,
             ]
         ));
 


### PR DESCRIPTION
Save buffer of conversion action events in cache folder.

Fixes:
![image](https://user-images.githubusercontent.com/6768917/164677345-65965654-34fe-4539-b120-fc031a5c0049.png)
