### PR TITLE
Add common data on conversion action about purchase to avoid conversion value = 1

### DIFF
--- a/classes/DTO/Remarketing/PurchaseEventData.php
+++ b/classes/DTO/Remarketing/PurchaseEventData.php
@@ -20,9 +20,9 @@
 
 namespace PrestaShop\Module\PsxMarketingWithGoogle\DTO\Remarketing;
 
-use JsonSerializable;
+use PrestaShop\Module\PsxMarketingWithGoogle\DTO\ConversionEventData;
 
-class PurchaseEventData implements JsonSerializable
+class PurchaseEventData extends ConversionEventData
 {
     /**
      * @var ProductData[]
@@ -45,25 +45,22 @@ class PurchaseEventData implements JsonSerializable
     protected $awFeedLanguage;
 
     /**
-     * @var string|null
-     */
-    protected $sendTo;
-
-    /**
      * @var float
      */
     protected $discount;
 
     public function jsonSerialize(): array
     {
-        return [
-            'send_to' => $this->sendTo,
-            'items' => $this->items,
-            'discount' => $this->discount,
-            'aw_merchant_id' => $this->awMerchandId,
-            'aw_feed_country' => $this->awFeedCountry,
-            'aw_feed_language' => $this->awFeedLanguage,
-        ];
+        return array_merge(
+            parent::jsonSerialize(),
+            [
+                'items' => $this->items,
+                'discount' => $this->discount,
+                'aw_merchant_id' => $this->awMerchandId,
+                'aw_feed_country' => $this->awFeedCountry,
+                'aw_feed_language' => $this->awFeedLanguage,
+            ]
+        );
     }
 
     /**
@@ -118,18 +115,6 @@ class PurchaseEventData implements JsonSerializable
     public function setItems(array $items)
     {
         $this->items = $items;
-
-        return $this;
-    }
-
-    /**
-     * @param string|null $sendTo
-     *
-     * @return self
-     */
-    public function setSendTo($sendTo)
-    {
-        $this->sendTo = $sendTo;
 
         return $this;
     }

--- a/classes/Provider/PurchaseEventDataProvider.php
+++ b/classes/Provider/PurchaseEventDataProvider.php
@@ -71,14 +71,21 @@ class PurchaseEventDataProvider
 
     /**
      * Return the items concerned by the transaction
+     *
+     * @see https://support.google.com/google-ads/answer/9028614
      */
     public function getEventData($sendTo, Order $order): PurchaseEventData
     {
         $purchaseData = new PurchaseEventData();
+        // Common details
+        $purchaseData->setSendTo($sendTo);
+        $purchaseData->setCurrency($this->context->currency->iso_code);
+        $purchaseData->setValue((string) $order->total_products_wt);
+        $purchaseData->setTransactionId($order->reference);
 
+        // CwCD Parameters
         $purchaseData->setDiscount((float) $order->total_discounts_tax_incl);
         $purchaseData->setAwMerchandId((int) $this->configurationAdapter->get(Config::REMARKETING_CONVERSION_MERCHANT_GMC_ID));
-        $purchaseData->setSendTo($sendTo);
         $purchaseData->setAwFeedCountry(
             $this->countryRepository->getIsoById(
                 $this->context->country->id


### PR DESCRIPTION
Conversion value wasn't reported properly, as basic data was replaced by other details specified on https://support.google.com/google-ads/answer/9028614. They are now merged together (basic + specific), and the debugger now shows the actual cart total.

![image](https://user-images.githubusercontent.com/6768917/164729448-a40f66ca-ab21-449d-acf9-2ff3575aa46c.png)
