### PR TITLE
Keep the Google verification tag displayed after website is verified and claimed

### DIFF
--- a/_dev/src/store/modules/accounts/actions.ts
+++ b/_dev/src/store/modules/accounts/actions.ts
@@ -310,6 +310,7 @@ export default {
     commit,
     rootState,
     state,
+    dispatch,
   }, correlationId: string) {
     if (state.googleMerchantAccount.id) {
       if (!correlationId) {
@@ -333,6 +334,7 @@ export default {
         throw new HttpClientError(response.statusText, response.status);
       }
     }
+    dispatch(ActionsTypes.SAVE_WEBSITE_VERIFICATION_META, false);
     commit(MutationsTypes.REMOVE_GMC);
     commit(MutationsTypes.SAVE_MCA_CONNECTED_ONCE, false);
     commit(`googleAds/${MutationsTypesGoogleAds.SET_GOOGLE_ADS_ACCOUNT}`, '', {root: true});
@@ -389,9 +391,6 @@ export default {
     } catch (error) {
       console.error(`Could not trigger website verification process: ${(<any>error)?.message}`);
       throw error;
-    } finally {
-      // Remove token anyway
-      await dispatch(ActionsTypes.SAVE_WEBSITE_VERIFICATION_META, false);
     }
   },
 


### PR DESCRIPTION
I recently saw my website was unverified again. It appears Google regurarly checks if the verification tag remains present.

On the documentation (https://support.google.com/merchants/answer/176793?hl=en#zippy=%2Cadd-an-html-tag), we can also read:

![image](https://user-images.githubusercontent.com/6768917/170457238-211e4a47-5fd0-4df8-bb82-405e3b9d5fc7.png)

From now, the tag will only be removed when the GMC account is disconnected.