### PR TITLE
Fix release reported on Sentry

### DIFF
--- a/_dev/src/utils/Sentry.ts
+++ b/_dev/src/utils/Sentry.ts
@@ -28,6 +28,6 @@ if (store.state.app.psxMktgWithGoogleOnProductionEnvironment) {
       },
     },
     // @ts-ignore
-    release: `v${appVersion}`,
+    release: appVersion,
   });
 }


### PR DESCRIPTION
Remove a double `v` in the release tag.
![image](https://user-images.githubusercontent.com/6768917/170458007-739791b8-29eb-4b6d-91f5-27299b0b2a71.png)
