### PR TITLE
Add tooltip to header product feed table prescan

### DIFF
--- a/_dev/src/assets/json/translations/en/ui.json
+++ b/_dev/src/assets/json/translations/en/ui.json
@@ -603,11 +603,12 @@
         "language": "Language",
         "image": "Image",
         "description": "Description",
-        "barcode": "Barcode/Brand",
+        "barcode": "MPN",
         "price": "Price"
       },
       "xHasFailedPreValidation" : "\"{0}\": has failed the pre-validation.",
-      "xHasPassedPreValidation" : "\"{0}\": has passed the pre-validation."
+      "xHasPassedPreValidation" : "\"{0}\": has passed the pre-validation.",
+      "labelTooltip": "This attribute matches what you have configued in your product attribute mapping : short description, description..."
     },
     "approvalTable": {
       "description": "These are the status of your products that are sent to Google Merchant Center. Some products might appear more than once because of their language variation.",
@@ -619,7 +620,7 @@
       "tableHeaderID": "ID",
       "tableHeaderAttributeID": "Attribute",
       "tableHeaderDestination": "Destination",
-      "tableHeaderName": "Name",
+      "tableHeaderName": "Title",
       "tableHeaderGoogleValidation": "Availablity for Google",
       "tableHeaderLanguage": "Language",
       "tableHeaderCountry": "Country",

--- a/_dev/src/components/product-feed-page/product-feed-pre-scan-table-status-details.vue
+++ b/_dev/src/components/product-feed-page/product-feed-pre-scan-table-status-details.vue
@@ -81,6 +81,15 @@
               tabindex="0"
             >
               {{ type.label }}
+              <b-button
+                v-if="hasToolTip(type)"
+                variant="invisible"
+                v-b-tooltip:psxMktgWithGoogleApp
+                :title="$t(`productFeedSettings.preScan.${type.tooltip}`)"
+                class="p-0 mt-0 ml-1 border-0 d-inline-flex align-items-center"
+              >
+                <i class="material-icons ps_gs-fz-14 text-secondary">info_outlined</i>
+              </b-button>
             </b-th>
           </b-tr>
         </b-thead>
@@ -225,10 +234,12 @@ export default {
         {
           key: 'description',
           label: this.$i18n.t('productFeedPage.preScan.fields.description'),
+          tooltip: 'labelTooltipDescription',
         },
         {
           key: 'barcode',
           label: this.$i18n.t('productFeedPage.preScan.fields.barcode'),
+          tooltip: 'labelTooltipBarcode',
         },
         {
           key: 'price',
@@ -335,6 +346,9 @@ export default {
     pageChanged(newPage) {
       this.currentPage = newPage;
       this.getPreScanProducts();
+    },
+    hasToolTip(type) {
+      return type.tooltip;
     },
   },
   mounted() {


### PR DESCRIPTION
![Capture d’écran 2022-06-06 à 11 03 10](https://user-images.githubusercontent.com/37299291/172130605-1056544c-8171-4fb4-a849-5aac090a18c2.png)
