### PR TITLE
Do not display Pmax when the campaign type is not known

### DIFF
--- a/_dev/src/components/smart-shopping-campaign/reporting/campaigns-performance/campaigns-performance-table-row.vue
+++ b/_dev/src/components/smart-shopping-campaign/reporting/campaigns-performance/campaigns-performance-table-row.vue
@@ -21,8 +21,9 @@
       <b-badge
         variant="type"
         class="ps_gs-fz-12 m-1"
+        v-if="campaignType"
       >
-        {{ campaignType(campaign) }}
+        {{ campaignType }}
       </b-badge>
     </b-td>
     <b-td
@@ -67,6 +68,15 @@ export default {
     currencyCode() {
       return this.$store.getters['googleAds/GET_GOOGLE_ADS_ACCOUNT_CHOSEN']?.currencyCode;
     },
+    campaignType() {
+      if (this.campaign.type === CampaignTypes.SMART_SHOPPING) {
+        return 'SSC';
+      }
+      if (this.campaign.type === CampaignTypes.PERFORMANCE_MAX) {
+        return 'PMax';
+      }
+      return null;
+    },
   },
   methods: {
     goToCampaignPage() {
@@ -76,12 +86,6 @@ export default {
           id: this.campaign.id,
         },
       });
-    },
-    campaignType(campaign) {
-      if (campaign.type === CampaignTypes.SMART_SHOPPING) {
-        return 'SSC';
-      }
-      return 'PMax';
     },
   },
 };

--- a/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list-row.vue
+++ b/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list-row.vue
@@ -15,8 +15,9 @@
       <b-badge
         variant="type"
         class="ps_gs-fz-12 m-1"
+        v-if="campaignType"
       >
-        {{ campaignType(campaign) }}
+        {{ campaignType }}
       </b-badge>
     </b-td>
     <b-td class="ps_gs-fz-12 text-nowrap">
@@ -121,6 +122,15 @@ export default {
         )
         : this.$t('smartShoppingCampaignCreation.inputAllSyncedProducts');
     },
+    campaignType() {
+      if (this.campaign.type === CampaignTypes.SMART_SHOPPING) {
+        return 'SSC';
+      }
+      if (this.campaign.type === CampaignTypes.PERFORMANCE_MAX) {
+        return 'PMax';
+      }
+      return null;
+    },
   },
   methods: {
     goToCampaignPage() {
@@ -147,12 +157,6 @@ export default {
         status: CampaignStatusToggle.ENABLED,
       };
       this.$store.dispatch('smartShoppingCampaigns/CHANGE_STATUS_OF_SSC', payload);
-    },
-    campaignType(campaign) {
-      if (campaign.type === CampaignTypes.SMART_SHOPPING) {
-        return 'SSC';
-      }
-      return 'PMax';
     },
   },
   googleUrl,


### PR DESCRIPTION
Currently the API does not return the campaign type on the reporting tab, and our interface displays "PMax" by default. This PR removes the label when the API does not give this information.

Screenshot from storybook:
![image](https://user-images.githubusercontent.com/6768917/175078632-618d81b4-34e8-4c52-bf9b-67437e94306a.png)
