### PR TITLE
Show campaign type dropdown as disabled when there is only one type of campaign available

### DIFF
--- a/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list.vue
+++ b/_dev/src/components/smart-shopping-campaign/smart-shopping-campaign-table-list.vue
@@ -22,7 +22,7 @@
           {{ $t('cta.viewReporting') }}
         </b-button>
         <b-dropdown
-          v-if="pMaxCampaignsList.length > 0 && sscCampaignsList.length > 0"
+          :disabled="pMaxCampaignsList.length === 0 || sscCampaignsList.length === 0"
           id="filterByCampaignTypeDropdown"
           variant="outline-primary"
           :text="$t('smartShoppingCampaignList.campaignType',


### PR DESCRIPTION
The button was displayed after the loading of SSC and PMax campaigns, and could be missed by merchants as it may appeared after a few seconds.
This PR makes it disabled instead.

![Capture d’écran du 2022-06-29 11-19-46](https://user-images.githubusercontent.com/6768917/176413827-8e4304b8-d18d-441d-aebf-51144f925187.png)
