### PR TITLE
Load first page of SSC and PMax when app is initialized

### DIFF
--- a/_dev/src/views/campaign-list.vue
+++ b/_dev/src/views/campaign-list.vue
@@ -62,6 +62,7 @@ export default {
         this.$store.dispatch('productFeed/GET_PRODUCT_FEED_SETTINGS'),
         this.$store.dispatch('productFeed/GET_PRODUCT_FEED_SYNC_SUMMARY'),
         this.$store.dispatch('smartShoppingCampaigns/GET_CAMPAIGNS_LIST', {isNewRequest: true, typeChosen: this.$options.CampaignTypes.PERFORMANCE_MAX}),
+        this.$store.dispatch('smartShoppingCampaigns/GET_CAMPAIGNS_LIST', {isNewRequest: true, typeChosen: this.$options.CampaignTypes.SMART_SHOPPING}),
         this.$store.dispatch('smartShoppingCampaigns/GET_REMARKETING_TRACKING_TAG_STATUS_MODULE'),
         this.$store.dispatch('smartShoppingCampaigns/GET_REMARKETING_CONVERSION_ACTIONS_ASSOCIATED'),
       ]);

--- a/_dev/src/views/campaign-page.vue
+++ b/_dev/src/views/campaign-page.vue
@@ -63,6 +63,7 @@ export default {
         this.$store.dispatch('productFeed/GET_PRODUCT_FEED_SETTINGS'),
         this.$store.dispatch('productFeed/GET_PRODUCT_FEED_SYNC_SUMMARY'),
         this.$store.dispatch('smartShoppingCampaigns/GET_CAMPAIGNS_LIST', {isNewRequest: true, typeChosen: this.$options.CampaignTypes.PERFORMANCE_MAX}),
+        this.$store.dispatch('smartShoppingCampaigns/GET_CAMPAIGNS_LIST', {isNewRequest: true, typeChosen: this.$options.CampaignTypes.SMART_SHOPPING}),
         this.$store.dispatch('smartShoppingCampaigns/GET_REMARKETING_TRACKING_TAG_STATUS_MODULE'),
         this.$store.dispatch('smartShoppingCampaigns/GET_REMARKETING_CONVERSION_ACTIONS_ASSOCIATED'),
       ]);


### PR DESCRIPTION
This PR fixes an issue where we get the message "Create your first campaign" when the user only has SSC campaigns.
We now initialize the app by loading the first page of PMax **AND** SSC campaigns.

This should be improved later with a warmup action.