### PR TITLE
Fix the carriage return for campaigns without link in reporting tab

### DIFF
--- a/_dev/src/components/smart-shopping-campaign/reporting/campaigns-performance/campaigns-performance-table-row.vue
+++ b/_dev/src/components/smart-shopping-campaign/reporting/campaigns-performance/campaigns-performance-table-row.vue
@@ -11,12 +11,12 @@
       >
         {{ campaign.name }}
       </b-button>
-      <div
+      <span
         v-else
         class="p-0 m-0 font-weight-normal ps_gs-fz-12"
       >
         {{ campaign.name }}
-      </div>
+      </span>
       <b-badge
         variant="type"
         class="ps_gs-fz-12 m-1"


### PR DESCRIPTION
From
![Capture d’écran du 2022-06-29 11-31-50](https://user-images.githubusercontent.com/6768917/176416440-ec5b2dcd-b8be-499f-9f75-7d96a506079b.png)
 
To
![Capture d’écran du 2022-06-29 11-32-01](https://user-images.githubusercontent.com/6768917/176416456-b046e856-bc66-471a-856f-1e4c15eab1f9.png)

