### PR TITLE
Fix display of currency on campaign list + fix language context when formating a price

### DIFF
--- a/_dev/.storybook/preview.js
+++ b/_dev/.storybook/preview.js
@@ -136,8 +136,7 @@ import '../src/utils/Filters';
    },
    beforeCreate() {
      window.i18nSettings = {
-       languageLocale: 'en', // needed in _dev/src/store/modules/product-feed/actions.ts
-       languageCode: 'en-US', // needed in _dev/src/store/modules/product-feed/actions.ts
+       languageLocale: 'en-us', // needed in _dev/src/store/modules/product-feed/actions.ts
        isoCode: 'en',
      }
 

--- a/_dev/src/components/campaign-creation/campaign-creation-filter-popin/campaign-creation-popin-recap.vue
+++ b/_dev/src/components/campaign-creation/campaign-creation-filter-popin/campaign-creation-popin-recap.vue
@@ -74,7 +74,7 @@
         {{ $t('smartShoppingCampaignCreation.inputBudgetFeedback') }}
       </dt>
       <dd class="text-secondary mb-2">
-        {{ newCampaign.dailyBudget }} {{ newCampaign.currencyCode }}
+        {{ newCampaign.dailyBudget|formatPrice(newCampaign.currencyCode) }}
       </dd>
     </dl>
     <p>

--- a/_dev/src/components/campaign/campaign-table-list-row.vue
+++ b/_dev/src/components/campaign/campaign-table-list-row.vue
@@ -36,7 +36,7 @@
       {{ campaignProducts }}
     </b-td>
     <b-td class="ps_gs-fz-12">
-      {{ campaign.dailyBudget }} {{ campaign.currencyCode }}
+      {{ campaign.dailyBudget|formatPrice(campaign.currencyCode || currencyCode) }}
     </b-td>
     <td class="ps_gs-fz-12 text-center">
       <b-dropdown
@@ -130,6 +130,9 @@ export default {
         return 'PMax';
       }
       return null;
+    },
+    currencyCode() {
+      return this.$store.getters['googleAds/GET_GOOGLE_ADS_ACCOUNT_CHOSEN']?.currencyCode;
     },
   },
   methods: {

--- a/_dev/src/shims-tsx.d.ts
+++ b/_dev/src/shims-tsx.d.ts
@@ -11,7 +11,10 @@ declare global {
       psxMtgWithGoogleDefaultShopCountry: Array<string>,
       contextPsAccounts: any;
       translations: any;
-      i18nSettings: any;
+      i18nSettings: {
+        isoCode: string,
+        languageLocale: string,
+      };
       psxMktgWithGoogleApiUrl: String;
       psxMktgWithGoogleAdminUrl: String;
       psxMktgWithGoogleShopUrl: String;

--- a/_dev/src/store/modules/campaigns/actions.ts
+++ b/_dev/src/store/modules/campaigns/actions.ts
@@ -438,7 +438,7 @@ export default {
     const query = new URLSearchParams({
       startDate: state.reporting.request.dateRange.startDate,
       endDate: state.reporting.request.dateRange.endDate,
-      lang: window.i18nSettings.languageLocale.split('-')[0],
+      lang: window.i18nSettings.isoCode,
     });
 
     // add order in array format

--- a/_dev/src/store/modules/product-feed/actions.ts
+++ b/_dev/src/store/modules/product-feed/actions.ts
@@ -73,7 +73,7 @@ export default {
   },
   async [ActionsTypes.GET_PRODUCT_FEED_SYNC_STATUS]({commit, rootState}) {
     const params = {
-      lang: window.i18nSettings.languageLocale.split('-')[0],
+      lang: window.i18nSettings.isoCode,
       timezone: encodeURI(Intl.DateTimeFormat().resolvedOptions().timeZone),
     };
     const url = `${rootState.app.psxMktgWithGoogleApiUrl}/incremental-sync/status/?lang=${params.lang}&timezone=${params.timezone}`;
@@ -105,7 +105,7 @@ export default {
 
   async [ActionsTypes.GET_PRODUCT_FEED_SETTINGS]({commit, rootState}) {
     const params = {
-      lang: window.i18nSettings.languageLocale.split('-')[0],
+      lang: window.i18nSettings.isoCode,
       timezone: encodeURI(Intl.DateTimeFormat().resolvedOptions().timeZone),
     };
     const url = `${rootState.app.psxMktgWithGoogleApiUrl}/incremental-sync/settings/?lang=${params.lang}&timezone=${params.timezone}`;

--- a/_dev/src/utils/Filters.ts
+++ b/_dev/src/utils/Filters.ts
@@ -62,9 +62,10 @@ Vue.filter(
   }));
 
 Vue.filter(
-  'formatPrice', (value: number, currencyCode) => {
-    if (!currencyCode) {
-      return '--';
+  'formatPrice', (value: number, currencyCode?: string) => {
+    if (!currencyCode?.length) {
+      console.warn('No currency code provided when formating price');
+      return value;
     }
     return Intl.NumberFormat(window.i18nSettings.languageCode, {
       style: 'currency',

--- a/_dev/src/utils/Filters.ts
+++ b/_dev/src/utils/Filters.ts
@@ -4,7 +4,6 @@ import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone'; // dependent on utc plugin
 import utc from 'dayjs/plugin/utc';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
-import store from '@/store';
 import countriesSelectionOptions from '../assets/json/countries.json';
 
 dayjs.extend(utc);
@@ -67,7 +66,8 @@ Vue.filter(
       console.warn('No currency code provided when formating price');
       return value;
     }
-    return Intl.NumberFormat(window.i18nSettings.languageCode, {
+
+    return Intl.NumberFormat(window.i18nSettings.languageLocale, {
       style: 'currency',
       currency: currencyCode,
     }).format(value);


### PR DESCRIPTION
# Problem 1

The way we display a price was different between the reporting and campaign list.

This PR updates the campaign tab, and makes sure a number is always displayed even if we don't provide properly the currency code.

## Now
![Capture d’écran du 2022-07-13 14-06-09](https://user-images.githubusercontent.com/6768917/178740732-14381564-9a55-4990-9c89-22bc1d754f67.png)


## Before
![Capture d’écran du 2022-07-13 09-55-45](https://user-images.githubusercontent.com/6768917/178740760-041bf73a-8412-4992-9180-3cf32406449c.png)

# Problem 2

It appeared whatever the language we set in the back office, the way prices are displayed never changed.
This was caused by the use of a variable that did not exist.

## Now (English)
![Capture d’écran du 2022-07-14 08-56-22](https://user-images.githubusercontent.com/6768917/178936474-6cacd35a-8009-49d4-9503-f63003055eb2.png)

## Now (French)
![image](https://user-images.githubusercontent.com/6768917/178936567-d9aec8e4-ac6c-4f0a-a2a8-45fd57f0c02b.png)

