### PR TITLE
Use images use stored online instead of on the shop

### DIFF
--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -17,7 +17,25 @@ jobs:
     steps:
       - name: Get tag
         id: get_tag
-        run: echo ::set-output name=TAG::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: |
+          echo ::set-output name=TAG::$(echo $GITHUB_REF | cut -d / -f 3)
+          echo ::set-output name=MAJOR::$(echo ${{ inputs.version }} | cut -d / -f 3 | cut -d '.' -f 1)
+          echo ::set-output name=MINOR::$(echo ${{ inputs.version }} | cut -d / -f 3 | cut -d '.' -f 2)
+          echo ::set-output name=PATCH::$(echo ${{ inputs.version }} | cut -d / -f 3 | cut -d '.' -f 3)
+
+      - name: Get assets URL
+        id: get_assets_url
+        run: |
+          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+            echo ::set-output name=URL::https://storage.googleapis.com/psxmarketing-cdn/${MAJOR}.${MINOR}.${PATCH}/
+          else
+            echo ::set-output name=URL::https://storage.googleapis.com/psxmarketing-cdn/${MAJOR}.x.x/
+          fi
+        env:
+          MAJOR: ${{ steps.get_tag.outputs.MAJOR }}
+          MINOR: ${{ steps.get_tag.outputs.MINOR }}
+          PATCH: ${{ steps.get_tag.outputs.PATCH }}
+
 
       - name: Trigger storage
         uses: aurelien-baudet/workflow-dispatch@v2
@@ -26,4 +44,4 @@ jobs:
           repo: PrestaShopCorp/services-deployment
           token: ${{ secrets.ACCESS_TOKEN }}
           ref: 'refs/heads/main'
-          inputs: '{ "version": "${{ steps.get_tag.outputs.TAG }}", "nodeVersion": "${{ env.NODE_VERSION }}", "vuejsPath": "${{ env.VUE_PATH }}", "vuejsBuildPath": "${{ env.BUILD_PATH }}", "isRelease": "${{ !github.event.release.prerelease && true || false }}" }'
+          inputs: '{ "version": "${{ steps.get_tag.outputs.TAG }}", "nodeVersion": "${{ env.NODE_VERSION }}", "vuejsPath": "${{ env.VUE_PATH }}", "vuejsBuildPath": "${{ env.BUILD_PATH }}", "isRelease": "${{ !github.event.release.prerelease && true || false }}", "assetsUrl": "${{ steps.get_assets_url.outputs.URL }}" }'

--- a/_dev/vue.config.js
+++ b/_dev/vue.config.js
@@ -55,5 +55,5 @@ module.exports = {
   filenameHashing: false,
   outputDir: '../views/',
   assetsDir: '',
-  publicPath: process.env.PSX_MKTG_WITH_GOOGLE_CDN_URL || '../modules/psxmarketingwithgoogle/views/',
+  publicPath: process.env.VUE_APP_ASSETS_URL || '../modules/psxmarketingwithgoogle/views/',
 };


### PR DESCRIPTION
At the moment, the app hosted on the CDN still tries to load the images stored on a shop (i.e `../modules/psxmarketingwithgoogle/views/img/pmax-modal-pmax-released-FR.png`). This means that for merchants who do not upgrade their module, some new images may be missing.