### PR TITLE
Forbid setting campaigns end date before today

### DIFF
--- a/_dev/src/assets/json/translations/en/ui.json
+++ b/_dev/src/assets/json/translations/en/ui.json
@@ -877,7 +877,7 @@
     "createCampaign": "Create campaign",
     "editCampaign": "Update campaign",
     "launchCampaign": "Launch campaign",
-    "resetDate": "Reset date",
+    "resetDate": "Set today's date",
     "validate": "Validate",
     "moreInfosAboutX": "More infos about {0}",
     "seeOnGoogleAds": "See on Google Ads",

--- a/_dev/src/components/campaign-creation/campaign-creation.spec.ts
+++ b/_dev/src/components/campaign-creation/campaign-creation.spec.ts
@@ -5,7 +5,7 @@ import Vuex from 'vuex';
 
 // Import this file first to init mock on window
 import cloneDeep from 'lodash.clonedeep';
-import {mount, shallowMount} from '@vue/test-utils';
+import {MountOptions, shallowMount} from '@vue/test-utils';
 import config, {localVue, cloneStore} from '@/../tests/init';
 
 import {initialStateApp} from '../../../.storybook/mock/state-app';
@@ -14,41 +14,48 @@ import {campaignWithUnhandledFilters, campaignWithoutUnhandledFilters, available
 import CampaignCreation from './campaign-creation.vue';
 
 const VBTooltip = jest.fn();
+const buildWrapper = (
+  options: MountOptions<any> = {},
+) => {
+  const store = cloneStore();
+
+  store.modules.productFeed.state.app = {
+    ...cloneDeep(initialStateApp),
+  };
+  store.modules.productFeed.state.googleAds = {
+    ...cloneDeep(googleAdsAccountChosen),
+  };
+
+  store.modules.campaigns.state.sscAvailableFilters = availableFilters;
+  store.modules.campaigns.state.errorCampaignNameExists = false;
+
+  return shallowMount(CampaignCreation, {
+    localVue,
+    store: new Vuex.Store(store),
+    directives: {
+      'b-tooltip': VBTooltip,
+    },
+    ...config,
+    stubs: {
+      VueShowdown: true,
+    },
+    mocks: {
+      $route: {
+        name: 'campaign-edition',
+        params: {
+          type: 'PERFORMANCE_MAX',
+        },
+      },
+    },
+    ...options,
+  });
+};
 
 describe('campaign-creation.vue - Campaign creation', () => {
-  let store;
   let wrapper;
-  const mockRoute = {
-    name: 'campaign-creation',
-    params: {
-      type: 'SHOPPING_CAMPAIGN',
-    },
-  };
+
   beforeEach(() => {
-    store = cloneStore();
-
-    store.modules.productFeed.state.app = {
-      ...cloneDeep(initialStateApp),
-    };
-    store.modules.productFeed.state.googleAds = {
-      ...cloneDeep(googleAdsAccountChosen),
-    };
-
-    store.modules.campaigns.state.sscAvailableFilters = availableFilters;
-
-    wrapper = shallowMount(CampaignCreation, {
-      localVue,
-      store: new Vuex.Store(store),
-      directives: {
-        'b-tooltip': VBTooltip,
-      },
-      ...config,
-      stubs: {
-        VueShowdown: true,
-      },
-      mocks: {
-        $route: mockRoute,
-      },
+    wrapper = buildWrapper({
       data() {
         return campaignWithoutUnhandledFilters;
       },
@@ -66,38 +73,17 @@ describe('campaign-creation.vue - Campaign creation', () => {
 });
 
 describe('campaign-creation.vue - Campaign edition', () => {
-  let store;
   let wrapper;
-  const mockRoute = {
-    name: 'campaign-edition',
-    params: {
-      type: 'SMART_SHOPPING_CAMPAIGN',
-    },
-  };
+
   beforeEach(() => {
-    store = cloneStore();
-
-    store.modules.productFeed.state.app = {
-      ...cloneDeep(initialStateApp),
-    };
-    store.modules.productFeed.state.googleAds = {
-      ...cloneDeep(googleAdsAccountChosen),
-    };
-
-    store.modules.campaigns.state.sscAvailableFilters = availableFilters;
-
-    wrapper = shallowMount(CampaignCreation, {
-      localVue,
-      store: new Vuex.Store(store),
-      directives: {
-        'b-tooltip': VBTooltip,
-      },
-      ...config,
-      stubs: {
-        VueShowdown: true,
-      },
+    wrapper = buildWrapper({
       mocks: {
-        $route: mockRoute,
+        $route: {
+          name: 'campaign-edition',
+          params: {
+            type: 'SMART_SHOPPING_CAMPAIGN',
+          },
+        },
       },
       data() {
         return campaignWithoutUnhandledFilters;
@@ -129,39 +115,10 @@ describe('campaign-creation.vue - Campaign edition', () => {
 });
 
 describe('campaign-creation.vue - Campaign edition - No active products', () => {
-  let store;
   let wrapper;
-  const mockRoute = {
-    name: 'campaign-edition',
-    params: {
-      type: 'PERFORMANCE_MAX',
-    },
-  };
+
   beforeEach(() => {
-    store = cloneStore();
-
-    store.modules.productFeed.state.app = {
-      ...cloneDeep(initialStateApp),
-    };
-    store.modules.productFeed.state.googleAds = {
-      ...cloneDeep(googleAdsAccountChosen),
-    };
-
-    store.modules.campaigns.state.sscAvailableFilters = availableFilters;
-
-    wrapper = shallowMount(CampaignCreation, {
-      localVue,
-      store: new Vuex.Store(store),
-      directives: {
-        'b-tooltip': VBTooltip,
-      },
-      ...config,
-      stubs: {
-        VueShowdown: true,
-      },
-      mocks: {
-        $route: mockRoute,
-      },
+    wrapper = buildWrapper({
       data() {
         return campaignWithoutUnhandledFilters;
       },
@@ -192,37 +149,10 @@ describe('campaign-creation.vue - Campaign edition - No active products', () => 
 });
 
 describe('campaign-creation.vue - Campaign edition - Unhandled filters', () => {
-  let store;
   let wrapper;
-  const mockRoute = {
-    name: 'campaign-edition',
-    params: {
-      type: 'PERFORMANCE_MAX',
-    },
-  };
+
   beforeEach(() => {
-    store = cloneStore();
-
-    store.modules.productFeed.state.app = {
-      ...cloneDeep(initialStateApp),
-    };
-    store.modules.productFeed.state.googleAds = {
-      ...cloneDeep(googleAdsAccountChosen),
-    };
-
-    wrapper = shallowMount(CampaignCreation, {
-      localVue,
-      store: new Vuex.Store(store),
-      directives: {
-        'b-tooltip': VBTooltip,
-      },
-      ...config,
-      stubs: {
-        VueShowdown: true,
-      },
-      mocks: {
-        $route: mockRoute,
-      },
+    wrapper = buildWrapper({
       data() {
         return campaignWithUnhandledFilters;
       },
@@ -260,5 +190,50 @@ describe('campaign-creation.vue - Campaign edition - Unhandled filters', () => {
   it('shows & disables the button "Select filters"', () => {
     expect(wrapper.find('#campaign-products-filter-fieldset b-button').isVisible()).toBe(true);
     expect(wrapper.find('#campaign-products-filter-fieldset b-button').attributes('disabled')).toBeTruthy();
+  });
+});
+
+describe('campaign-creation.vue - Campaign edition - End date validation', () => {
+  it('allows to continue when end date is not set', () => {
+    const wrapper = buildWrapper({
+      data() {
+        return {
+          ...campaignWithUnhandledFilters,
+          campaignDurationStartDate: 'Fri Oct 01 2021 01:00:00 GMT+0100 (heure d’été britannique)',
+          campaignDurationEndDate: null,
+        };
+      },
+    });
+    expect(wrapper.vm.campaignEndDateFeedback).toBe(null);
+    expect(wrapper.find('[data-test-id="createCampaignButton"]').attributes('disabled')).toBeFalsy();
+  });
+
+  it('allows to continue when end date is acceptable', () => {
+    const wrapper = buildWrapper({
+      data() {
+        return {
+          ...campaignWithUnhandledFilters,
+          campaignDurationStartDate: 'Fri Oct 01 2021 01:00:00 GMT+0100 (heure d’été britannique)',
+          // Year 3999 to make sure it always in the future
+          campaignDurationEndDate: 'Fri Oct 11 3999 01:00:00 GMT+0100 (heure d’été britannique)',
+        };
+      },
+    });
+    expect(wrapper.vm.campaignEndDateFeedback).toBe(null);
+    expect(wrapper.find('[data-test-id="createCampaignButton"]').attributes('disabled')).toBeFalsy();
+  });
+
+  it('warns merchant & prevents sending the form when end date does not match requierements', () => {
+    const wrapper = buildWrapper({
+      data() {
+        return {
+          ...campaignWithUnhandledFilters,
+          campaignDurationStartDate: 'Fri Oct 01 2021 01:00:00 GMT+0100 (heure d’été britannique)',
+          campaignDurationEndDate: 'Fri Oct 11 2021 01:00:00 GMT+0100 (heure d’été britannique)',
+        };
+      },
+    });
+    expect(wrapper.vm.campaignEndDateFeedback).toBe(false);
+    expect(wrapper.find('[data-test-id="createCampaignButton"]').attributes('disabled')).toBeTruthy();
   });
 });

--- a/_dev/src/components/campaign-creation/campaign-creation.vue
+++ b/_dev/src/components/campaign-creation/campaign-creation.vue
@@ -189,18 +189,16 @@
                       month: 'numeric',
                       day: 'numeric',
                     }"
-                    :min="campaignDurationStartDate"
+                    :min="minimunEndDate"
                     reset-button
-                    :label-reset-button="$t('cta.resetDate')"
+                    :label-reset-button="$t('cta.noEndDate')"
                     reset-button-variant="outline-secondary sm"
-                    close-button
-                    :label-close-button="$t('cta.noEndDate')"
-                    close-button-variant="outline-secondary sm"
                     :hide-header="true"
                     :label-help="
                       $t('smartShoppingCampaignCreation.inputDatePickerHelper')
                     "
                     :required="false"
+                    :state="campaignEndDateFeedback"
                     class="ps_gs-datepicker"
                     menu-class="ps_gs-datepicker-end"
                   />
@@ -524,10 +522,14 @@ export default {
         && this.campaignDurationStartDate
         && (this.targetCountry || this.defaultCountry())
         && this.campaignDailyBudget
+        && this.campaignEndDateFeedback !== false
       ) {
         return false;
       }
       return true;
+    },
+    minimunEndDate() {
+      return new Date(Math.max(new Date(this.campaignDurationStartDate), new Date()));
     },
     campaignNameFeedback() {
       if (
@@ -545,6 +547,17 @@ export default {
         return true;
       }
       return false;
+    },
+    campaignEndDateFeedback() {
+      if (this.campaignDurationEndDate
+        && new Date(this.campaignDurationEndDate) < this.minimunEndDate
+      ) {
+        // Show as NOK
+        return false;
+      }
+
+      // No feedback to display, either OK or NOK
+      return null;
     },
     campaignDailyBudgetFeedback() {
       const regex = /^[0-9]+([.][0-9]{0,2})?$/g;

--- a/_dev/tests/init.ts
+++ b/_dev/tests/init.ts
@@ -14,6 +14,7 @@ beforeEach(() => {
     // add data needed in window
     scrollTo: jest.fn(),
     addEventListener: jest.fn(),
+    i18nSettings: {isoCode: 'fr', languageLocale: 'fr'},
   }));
   VBTooltip = jest.fn();
   localVue = createLocalVue();


### PR DESCRIPTION
* Update minimal value of campaigns end date so the merchant cannot select a day before today's date or the campaign start date
* Changes the buttons in the end date datepicker: We had issues where removing the date only closed the calendar, but resetting the date actually removed the date. This PR updates the buttons to only keep the one that removes the date.
* Show the end date in a different state when it is before today's date.

![Capture d’écran du 2022-07-14 11-18-27](https://user-images.githubusercontent.com/6768917/178961472-ed37f554-46bb-41ad-9a0e-c214b74c1536.png)
 