### PR TITLE
Display countries while importing shipping settings only if they have one associated carrier

### DIFF
--- a/_dev/src/components/product-feed/settings/delivery-time-and-rates/delivery-time-and-rates.vue
+++ b/_dev/src/components/product-feed/settings/delivery-time-and-rates/delivery-time-and-rates.vue
@@ -6,6 +6,7 @@
     <target-countries
       @countrySelected="countries = $event"
       :countries="countries"
+      :shipping-setup-option="getShippingValueSetup"
     />
     <shipping-settings
       v-if="getShippingValueSetup === ShippingSetupOption.IMPORT"
@@ -30,7 +31,7 @@
 import Vue from 'vue';
 import {ShippingSetupOption} from '@/enums/product-feed/shipping';
 import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
-import ShippingSettingsHeaderType from '@/enums/product-feed/shipping-settings-header-type.ts';
+import ShippingSettingsHeaderType from '@/enums/product-feed/shipping-settings-header-type';
 import ActionsButtons from '@/components/product-feed/settings/commons/actions-buttons.vue';
 import SegmentGenericParams from '@/utils/SegmentGenericParams';
 import TargetCountries from '@/components/product-feed/settings/delivery-time-and-rates/target-countries.vue';

--- a/_dev/src/utils/LocalStorage.ts
+++ b/_dev/src/utils/LocalStorage.ts
@@ -20,6 +20,7 @@ export function deleteProductFeedDataFromLocalStorage() {
   localStorage.removeItem('productFeed-attributeMapping');
   localStorage.removeItem('productFeed-targetCountries');
   localStorage.removeItem('productFeed-autoImportShippingSettings');
+  localStorage.removeItem('productFeed-shippingSetup');
   localStorage.removeItem('selectedProductCategories');
 }
 

--- a/_dev/stories/product-feed-settings.stories.ts
+++ b/_dev/stories/product-feed-settings.stories.ts
@@ -1,3 +1,4 @@
+import cloneDeep from 'lodash.clonedeep';
 import TunnelProductFeed from '../src/views/tunnel-product-feed.vue';
 import {productFeed, productFeedNoCarriers ,productFeedIsReadyForExport, productFeedSyncScheduleNow} from '../.storybook/mock/product-feed';
 import {shippingPhpExportWithIssues} from '../.storybook/mock/shipping-settings';
@@ -7,6 +8,7 @@ import {rest} from 'msw';
 import ProductFeedSettingsPages from '@/enums/product-feed/product-feed-settings-pages';
 import { ShippingSetupOption } from '@/enums/product-feed/shipping';
 import { getEnabledCarriers, mergeShippingDetailsSourcesForProductFeedConfiguration } from '../src/providers/shipping-settings-provider';
+import { deleteProductFeedDataFromLocalStorage } from '../src/utils/LocalStorage';
 
 export default {
   title: 'Product feed/Settings',
@@ -94,13 +96,16 @@ const Template = (args, {argTypes}) => ({
   components: {TunnelProductFeed},
   template: '<div><TunnelProductFeed v-bind="$props" /></div>',
   beforeMount: args.beforeMount,
+  beforeCreate() {
+    deleteProductFeedDataFromLocalStorage();
+  }
 });
 
 export const SettingsSetup:any = Template.bind({});
 SettingsSetup.args = {
   beforeMount(this: any) {
-    this.$store.state.productFeed = Object.assign({},productFeed);
-    this.$store.state.app = Object.assign({},initialStateApp);
+    this.$store.state.productFeed = cloneDeep(productFeed);
+    this.$store.state.app = cloneDeep(initialStateApp);
     this.$store.state.productFeed.stepper = 1;
     this.$router.history.current.params.step = ProductFeedSettingsPages.SHIPPING_SETUP
   },
@@ -109,7 +114,7 @@ SettingsSetup.args = {
 export const EstimateDeliveryTimeAndRates:any = Template.bind({});
 EstimateDeliveryTimeAndRates.args = {
   beforeMount(this: any) {
-    this.$store.state.productFeed = Object.assign({},productFeed);
+    this.$store.state.productFeed = cloneDeep(productFeed);
     this.$store.state.productFeed.stepper = 2;
     this.$store.state.productFeed.settings.shippingSetup = ShippingSetupOption.ESTIMATE;
     this.$router.history.current.params.step = ProductFeedSettingsPages.SHIPPING_SETTINGS
@@ -119,7 +124,7 @@ EstimateDeliveryTimeAndRates.args = {
 export const ImportDeliveryTimeAndRates:any = Template.bind({});
 ImportDeliveryTimeAndRates.args = {
   beforeMount(this: any) {
-    this.$store.state.productFeed = Object.assign({}, productFeed);
+    this.$store.state.productFeed = cloneDeep( productFeed);
     this.$store.state.productFeed.stepper = 2;
     this.$store.state.productFeed.settings.shippingSetup = ShippingSetupOption.IMPORT;
     this.$router.history.current.params.step = ProductFeedSettingsPages.SHIPPING_SETTINGS
@@ -130,7 +135,7 @@ ImportDeliveryTimeAndRates.args = {
 export const ImportDeliveryTimeAndRatesNoCarriers:any = Template.bind({});
 ImportDeliveryTimeAndRatesNoCarriers.args = {
   beforeMount(this: any) {
-    this.$store.state.productFeed = Object.assign({},productFeedNoCarriers);
+    this.$store.state.productFeed = cloneDeep(productFeedNoCarriers);
     this.$store.state.productFeed.stepper = 2;
     this.$store.state.productFeed.settings.shippingSetup = ShippingSetupOption.IMPORT;
     this.$router.history.current.params.step = ProductFeedSettingsPages.SHIPPING_SETTINGS;
@@ -140,7 +145,7 @@ ImportDeliveryTimeAndRatesNoCarriers.args = {
 export const ImportDeliveryTimeAndRatesWithSpanishShippingModules:any = Template.bind({});
 ImportDeliveryTimeAndRatesWithSpanishShippingModules.args = {
   beforeMount(this: any) {
-    this.$store.state.productFeed = Object.assign({},productFeed);
+    this.$store.state.productFeed = cloneDeep(productFeed);
     this.$store.state.productFeed.settings.targetCountries = ['ES', 'PT'];
     this.$store.state.productFeed.settings.shippingSettings = shippingPhpExportWithIssues;
     this.$store.state.productFeed.settings.deliveryDetails = Object.assign([], mergeShippingDetailsSourcesForProductFeedConfiguration(getEnabledCarriers(shippingPhpExportWithIssues), []));
@@ -153,7 +158,7 @@ ImportDeliveryTimeAndRatesWithSpanishShippingModules.args = {
 export const ImportDeliveryTimeAndRatesWithManyCarriers:any = Template.bind({});
 ImportDeliveryTimeAndRatesWithManyCarriers.args = {
   beforeMount(this: any) {
-    this.$store.state.productFeed = Object.assign({},productFeed);
+    this.$store.state.productFeed = cloneDeep(productFeed);
     this.$store.state.productFeed.settings.targetCountries = ['SE'];
     this.$store.state.productFeed.settings.shippingSettings = shippingPhpExportWithIssues;
     this.$store.state.productFeed.settings.deliveryDetails = Object.assign([], mergeShippingDetailsSourcesForProductFeedConfiguration(getEnabledCarriers(shippingPhpExportHeavy), []));
@@ -166,7 +171,7 @@ ImportDeliveryTimeAndRatesWithManyCarriers.args = {
 export const AttributeMapping:any = Template.bind({});
 AttributeMapping.args = {
   beforeMount(this: any) {
-    this.$store.state.productFeed = Object.assign({},productFeed);
+    this.$store.state.productFeed = cloneDeep(productFeed);
     this.$store.state.productFeed.stepper = 3;
     this.$router.history.current.params.step = ProductFeedSettingsPages.ATTRIBUTE_MAPPING
   },
@@ -175,7 +180,7 @@ AttributeMapping.args = {
 export const SyncSchedule:any = Template.bind({});
 SyncSchedule.args = {
   beforeMount(this: any) {
-    this.$store.state.productFeed = Object.assign({},productFeedSyncScheduleNow);
+    this.$store.state.productFeed = cloneDeep(productFeedSyncScheduleNow);
     this.$store.state.productFeed.stepper = 4;
     this.$router.history.current.params.step = ProductFeedSettingsPages.SYNC_SCHEDULE
   },
@@ -184,7 +189,7 @@ SyncSchedule.args = {
 export const Summary:any = Template.bind({});
 Summary.args = {
   beforeMount(this: any) {
-    this.$store.state.productFeed = Object.assign({},productFeedIsReadyForExport);
+    this.$store.state.productFeed = cloneDeep(productFeedIsReadyForExport);
     this.$store.state.productFeed.stepper = 5;
     this.$router.history.current.params.step = ProductFeedSettingsPages.SUMMARY
   },


### PR DESCRIPTION
Based on https://github.com/PrestaShopCorp/psxmarketingwithgoogle/pull/1084, display countries in target countries options only if they have a carrier that delivers to it.