### PR TITLE
Fix PS Accounts on Storybook

### DIFF
--- a/_dev/.storybook/mock/ps-accounts.ts
+++ b/_dev/.storybook/mock/ps-accounts.ts
@@ -1,13 +1,14 @@
-import {PrestaShopAccountsContext} from "@/store/modules/accounts/state";
+import { PrestaShopAccountsContext } from "@/store/modules/accounts/state";
+import { cloneDeep } from "lodash";
 
 export const contextPsAccountsNotConnected: PrestaShopAccountsContext = {
   currentContext: {
     type: 1,
-    id: 1
+    id: 1,
   },
   psxName: "psxmarketingwithgoogle",
   psIs17: true,
-  accountsUiUrl:"https://accounts.distribution.prestashop.net/en",
+  accountsUiUrl: "https://accounts.distribution.prestashop.net/en",
   psAccountsIsInstalled: true,
   psAccountsInstallLink: null,
   psAccountsIsEnabled: true,
@@ -15,10 +16,16 @@ export const contextPsAccountsNotConnected: PrestaShopAccountsContext = {
   psAccountsIsUptodate: true,
   psAccountsUpdateLink: null,
   onboardingLink: "https://localhost",
+  backendUser: {
+    email: "admin@prestashop.com",
+    employeeId: 1,
+    isSuperAdmin: true,
+  },
   user: {
     email: null,
     emailIsValidated: false,
     isSuperAdmin: true,
+    uuid: null,
   },
   currentShop: {
     id: "1",
@@ -36,40 +43,64 @@ export const contextPsAccountsNotConnected: PrestaShopAccountsContext = {
     multishop: false,
     moduleName: "psxmarketingwithgoogle",
     psVersion: "1.7.7.4",
-    url: "https://placeholder.prestashop.com"
+    url: "https://placeholder.prestashop.com",
   },
   isShopContext: true,
-  shops: [{"id":"1","name":"Default","shops":[{"id":"1","name":"PrestaShop","domain":"placeholder.ngrok.io","domainSsl":"placeholder.ngrok.io","physicalUri":"/","uuid":"d232f98c-65c2-4adc-9352-da5e949531c1","publicKey":"-----BEGIN RSA PUBLIC KEY-----\r\nMIGJAoGBALbXq5oLm/GzCcPb6LSUjgoOue/NHf+XJckP3vlplocTnSW15yKWEAQ0\r\nJPOFHWOhEW9dHxrdv2XUw1vyHhIK3KwJMQnbdzOV0Y0oDPnjIsm3TNhkvHIhq2F2\r\nlPgCW1T1LvLUc+JD2PEMw21W2J5LLDnF/vdnLkqdMMfSmR+34OmDAgMBAAE=\r\n-----END RSA PUBLIC KEY-----","employeeId":1,"url":"https://placeholder.ngrok.io/admin-dev/index.php?controller=AdminModules&configure=psxmarketingwithgoogle&setShopContext=s-1&token=ba2e131a1d891745a4e5389b890fc105","isLinkedV4":false}],"multishop":false,"moduleName":"psxmarketingwithgoogle","psVersion":"1.7.7.2"}],
+  shops: [
+    {
+      id: "1",
+      name: "Default",
+      shops: [
+        {
+          id: "1",
+          name: "PrestaShop",
+          domain: "placeholder.ngrok.io",
+          domainSsl: "placeholder.ngrok.io",
+          physicalUri: "/",
+          publicKey:
+            "-----BEGIN RSA PUBLIC KEY-----\r\nMIGJAoGBALbXq5oLm/GzCcPb6LSUjgoOue/NHf+XJckP3vlplocTnSW15yKWEAQ0\r\nJPOFHWOhEW9dHxrdv2XUw1vyHhIK3KwJMQnbdzOV0Y0oDPnjIsm3TNhkvHIhq2F2\r\nlPgCW1T1LvLUc+JD2PEMw21W2J5LLDnF/vdnLkqdMMfSmR+34OmDAgMBAAE=\r\n-----END RSA PUBLIC KEY-----",
+          url: "https://placeholder.ngrok.io/admin-dev/index.php?controller=AdminModules&configure=psxmarketingwithgoogle&setShopContext=s-1&token=ba2e131a1d891745a4e5389b890fc105",
+          isLinkedV4: false,
+          user: {
+            email: null,
+            emailIsValidated: false,
+            isSuperAdmin: true,
+            uuid: null,
+          }
+        },
+      ],
+      multishop: false,
+      moduleName: "psxmarketingwithgoogle",
+      psVersion: "1.7.7.2",
+    },
+  ],
   superAdminEmail: "some@email.com",
-  ssoResendVerificationEmail: "https:\/\/auth.prestashop.com\/account\/send-verification-email",
-  manageAccountLink: "https:\/\/auth.prestashop.com\/login",
+  ssoResendVerificationEmail:
+    "https://auth.prestashop.com/account/send-verification-email",
+  manageAccountLink: "https://auth.prestashop.com/login",
   adminAjaxLink: "https://localhost",
   dependencies: {
     ps_eventbus: {
       isInstalled: true,
       installLink: "https://localhost",
       isEnabled: true,
-      enableLink: "https://localhost"
+      enableLink: "https://localhost",
     },
   },
 };
 
-export const contextPsAccountsConnected = {
-    ...contextPsAccountsNotConnected,
-    "user": {
-      "email": "doge@thedog.com",
-      "emailIsValidated": false,
-      "isSuperAdmin": true
-    },
+export const contextPsAccountsConnected = cloneDeep(contextPsAccountsNotConnected);
+contextPsAccountsConnected.user = {
+  email: "doge@thedog.com",
+  emailIsValidated: false,
+  isSuperAdmin: true,
 };
+contextPsAccountsConnected.currentShop.uuid = 'fbbfgbkmmobgnjmeoLkSpQIdtULl1';
+contextPsAccountsConnected.currentShop.user = contextPsAccountsConnected.user;
+contextPsAccountsConnected.shops[0].shops[0] = contextPsAccountsConnected.currentShop;
 
-export const contextPsAccountsConnectedAndValidated = {
-    ...contextPsAccountsConnected,
-    "user": {
-        ...contextPsAccountsConnected.user,
-        "emailIsValidated": true,
-    },
-};
+export const contextPsAccountsConnectedAndValidated = cloneDeep(contextPsAccountsConnected);
+contextPsAccountsConnectedAndValidated.currentShop.user.emailIsValidated = true;
 
 
 export default contextPsAccountsConnectedAndValidated;

--- a/_dev/.storybook/preview-head.html
+++ b/_dev/.storybook/preview-head.html
@@ -1,4 +1,0 @@
-<script>
-/* Needed by https://github.com/PrestaShopCorp/prestashop_accounts_vue_components/blob/b0f88cc1bede29ef865c4747558d117c80f566b1/src/full.js#L60 */
-var contextPsAccounts = {};
-</script>

--- a/_dev/.storybook/preview.js
+++ b/_dev/.storybook/preview.js
@@ -63,6 +63,7 @@ import '../src/utils/Filters';
  import results from '../.jest-test-results.json';
  import VueRouter from 'vue-router';
 
+ Vue.config.ignoredElements = ['prestashop-accounts'];
  Vue.use(BootstrapVue, BootstrapVueIcons);
  Vue.use(VueShowdown);
  Vue.use(VueRouter);

--- a/_dev/src/views/onboarding-page.vue
+++ b/_dev/src/views/onboarding-page.vue
@@ -262,9 +262,6 @@ export default {
     },
   },
   computed: {
-    psAccountsContext() {
-      return this.$store.getters['accounts/GET_PS_ACCOUNTS_CONTEXT'];
-    },
     shops() {
       return this.$store.getters['accounts/GET_PS_ACCOUNTS_CONTEXT_SHOPS'];
     },

--- a/_dev/stories/general-errors.stories.ts
+++ b/_dev/stories/general-errors.stories.ts
@@ -1,0 +1,34 @@
+import App from '@/App.vue'
+import {initialStateApp} from '../.storybook/mock/state-app';
+import {contextPsAccountsConnectedAndValidated} from "../.storybook/mock/ps-accounts";
+import {googleAccountNotConnected} from "../.storybook/mock/google-account";
+import {merchantCenterAccountNotConnected} from "../.storybook/mock/merchant-center-account";
+
+export default {
+  title: 'General/Errors',
+  component: App,
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: {App},
+  template: `
+    <App/>
+  `,
+  beforeMount: args.beforeMount,
+  watch: {},
+});
+
+export const UserIsDisconnectedFromBO:any = Template.bind({});
+UserIsDisconnectedFromBO.args = {
+  beforeMount(this: any) {
+    this.$store.state.app = Object.assign(
+      {},
+      this.$store.state.app,
+      initialStateApp
+    );
+    this.$store.state.accounts.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
+    this.$store.state.accounts.googleAccount = Object.assign({}, googleAccountNotConnected);
+    this.$store.state.accounts.googleMerchantAccount = Object.assign({}, merchantCenterAccountNotConnected);
+  },
+};

--- a/_dev/stories/onboarding-page.stories.ts
+++ b/_dev/stories/onboarding-page.stories.ts
@@ -22,6 +22,7 @@ const TemplatePsAccount = (args, { argTypes }) => ({
 export const PsAccount:any = TemplatePsAccount.bind({});
 PsAccount.args = {
   beforeMount: function(this: any) {
+    window.contextPsAccounts = Object.assign({}, contextPsAccountsNotConnected);
     this.$store.state.accounts.contextPsAccounts = Object.assign({}, contextPsAccountsNotConnected);
   }
 };
@@ -34,6 +35,7 @@ GoogleAccount.args = {
       this.$store.state.app,
       initialStateApp
     );
+    window.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
     this.$store.state.accounts.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
     this.$store.state.accounts.googleAccount = Object.assign({}, googleAccountNotConnected);
     this.$store.state.accounts.googleMerchantAccount = Object.assign({}, merchantCenterAccountNotConnected);
@@ -48,6 +50,7 @@ MerchantCenterAccount.args = {
       this.$store.state.app,
       initialStateApp
     );
+    window.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
     this.$store.state.accounts.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
     this.$store.state.accounts.googleAccount = Object.assign({}, googleAccountConnectedOnce);
     this.$store.state.accounts.googleMerchantAccount = Object.assign({}, merchantCenterAccountNotConnected);
@@ -62,6 +65,7 @@ ProductFeed.args = {
       this.$store.state.app,
       initialStateApp
     );
+    window.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
     this.$store.state.accounts.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
     this.$store.state.accounts.googleAccount = Object.assign({}, googleAccountConnected);
     this.$store.state.accounts.googleMerchantAccount = Object.assign({}, merchantCenterAccountConnectedOnce);
@@ -77,6 +81,7 @@ FreeListing.args = {
       this.$store.state.app,
       initialStateApp
     );
+    window.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
     this.$store.state.accounts.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
     this.$store.state.accounts.googleAccount = Object.assign({}, googleAccountConnected);
     this.$store.state.accounts.googleMerchantAccount = Object.assign({}, merchantCenterAccountConnected);
@@ -92,6 +97,7 @@ GoogleAds.args = {
       this.$store.state.app,
       initialStateApp
     );
+    window.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
     this.$store.state.accounts.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
     this.$store.state.accounts.googleAccount = Object.assign({}, googleAccountConnected);
     this.$store.state.accounts.googleMerchantAccount = Object.assign({}, merchantCenterAccountConnected);
@@ -108,6 +114,7 @@ campaigns.args = {
       this.$store.state.app,
       initialStateApp
     );
+    window.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
     this.$store.state.accounts.contextPsAccounts = Object.assign({}, contextPsAccountsConnectedAndValidated);
     this.$store.state.accounts.googleAccount = Object.assign({}, googleAccountConnected);
     this.$store.state.accounts.googleMerchantAccount = Object.assign({}, merchantCenterAccountConnected);

--- a/_dev/stories/ps-account-card.stories.ts
+++ b/_dev/stories/ps-account-card.stories.ts
@@ -1,4 +1,5 @@
-import {PsAccounts} from 'prestashop_accounts_vue_components';
+import { cloneDeep } from 'lodash';
+import psAccountsVue from 'prestashop_accounts_vue_components';
 import {
   contextPsAccountsNotConnected,
   contextPsAccountsConnected,
@@ -7,26 +8,37 @@ import {
 
 export default {
   title: 'PS Account/Card',
-  component: PsAccounts,
 };
 
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
-  components: { PsAccounts },
-  template: '<ps-accounts v-bind="$props" />',
+  template: '<prestashop-accounts />',
+  mounted: args.mounted,
 });
 
 export const NotConnected:any = Template.bind({});
 NotConnected.args = {
-  context: Object.assign({}, contextPsAccountsNotConnected),
+  mounted: function () {
+    window.contextPsAccounts = cloneDeep(contextPsAccountsNotConnected),
+    console.log('contextPsAccounts', window.contextPsAccounts)
+    psAccountsVue.init();
+  }
 }
 
 export const Connected:any = Template.bind({});
 Connected.args = {
-  context: Object.assign({}, contextPsAccountsConnected),
+  mounted: function () {
+    window.contextPsAccounts = cloneDeep(contextPsAccountsConnected),
+    console.log('contextPsAccounts', window.contextPsAccounts)
+    psAccountsVue.init();
+  }
 }
 
 export const ConnectedAndValidated:any = Template.bind({});
 ConnectedAndValidated.args = {
-  context: Object.assign({}, contextPsAccountsConnectedAndValidated),
+  mounted: function () {
+    window.contextPsAccounts = cloneDeep(contextPsAccountsConnectedAndValidated),
+    console.log('contextPsAccounts', window.contextPsAccounts)
+    psAccountsVue.init();
+  }
 }


### PR DESCRIPTION
PS Accounts now loads its context exclusively from `window`. We had to update our stories to make it work on Storybook.

![image](https://user-images.githubusercontent.com/6768917/199517689-99edbd9f-e1de-4c17-943b-69b423dfc89c.png)
