### PR TITLE
Add prefix URL to sourcemaps sent to Sentry so they can be used on stacktraces

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -231,4 +231,5 @@ jobs:
         with:
           environment: production
           version: ${{ github.ref }}
-          sourcemaps: _dev/sourcemaps views/js
+          sourcemaps: views/js
+          url_prefix: "~/psxmarketing-cdn/${MAJOR}.x.x/js"


### PR DESCRIPTION
@tberger-prestashop FYI