### PR TITLE
Improve verification tag renewal process from feedback

### DIFF
--- a/_dev/apps/verification-tag/src/index.ts
+++ b/_dev/apps/verification-tag/src/index.ts
@@ -34,7 +34,8 @@ const init = (): void => {
       allowUrls: [
         'https://storage.googleapis.com/psxmarketing-cdn/',
       ],
-      tracesSampleRate: 1.0,
+      sampleRate: 0.5,
+      tracesSampleRate: 1,
       initialScope: {
         user: {
           id: window.psxMktgWithGoogleShopIdPsAccounts ? window.psxMktgWithGoogleShopIdPsAccounts.toString() : 'unknown',

--- a/_dev/apps/verification-tag/src/verification-tag-retriever.spec.ts
+++ b/_dev/apps/verification-tag/src/verification-tag-retriever.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientError } from "mktg-with-google-common";
+import { fetchOnboarding, HttpClientError } from "mktg-with-google-common";
 import { runRetrievalOfVerificationTag } from "./verification-tag-retriever";
 
 describe('runRetrievalOfVerificationTag', () => {
@@ -17,19 +17,31 @@ describe('runRetrievalOfVerificationTag', () => {
     );
 
     // assert
-    expect(fetchOnboardingMock).toBeCalledTimes(2);
+    expect(fetchOnboardingMock).toBeCalledTimes(3);
     expect(fetchShopMock).toBeCalledTimes(1);
 
     expect(fetchOnboardingMock).toHaveBeenNthCalledWith(1,
       'GET',
       'shopping-websites/site-verification/token',
       expect.any(String),
+      undefined,
+      expect.any(Function),
     );
 
     expect(fetchOnboardingMock).toHaveBeenNthCalledWith(2,
       'POST',
       'shopping-websites/site-verification/verify',
       expect.any(String),
+      undefined,
+      expect.any(Function),
+    );
+
+    expect(fetchOnboardingMock).toHaveBeenNthCalledWith(3,
+      'POST',
+      'shopping-websites/site-verification/claim?overwrite=false',
+      expect.any(String),
+      undefined,
+      expect.any(Function),
     );
 
     expect(fetchShopMock).toHaveBeenNthCalledWith(1,
@@ -47,10 +59,14 @@ describe('runRetrievalOfVerificationTag', () => {
     fetchOnboardingMock.mockImplementationOnce(() => {throw new HttpClientError('oh no', 404)});
 
     // act
-    await runRetrievalOfVerificationTag(
-      fetchOnboardingMock,
-      fetchShopMock,
-    );
+    try {
+      await runRetrievalOfVerificationTag(
+        fetchOnboardingMock,
+        fetchShopMock,
+      );
+    } catch {
+      // Do nothing
+    }
 
     // assert
     expect(fetchOnboardingMock).toBeCalledTimes(1);

--- a/_dev/apps/verification-tag/src/verification-tag-retriever.ts
+++ b/_dev/apps/verification-tag/src/verification-tag-retriever.ts
@@ -1,18 +1,21 @@
 import * as Sentry from "@sentry/browser";
-import type {fetchOnboarding as fetchOnboardingType, fetchShop as fetchShopType} from 'mktg-with-google-common';
+import {fetchOnboarding as fetchOnboardingType, fetchShop as fetchShopType, HttpClientError} from 'mktg-with-google-common';
+
+const correlationId = `${Math.floor(Date.now() / 1000)}`;
+const scope = new Sentry.Scope();
 
 export const runRetrievalOfVerificationTag = async (
   fetchOnboarding: typeof fetchOnboardingType,
   fetchShop: typeof fetchShopType,
 ): Promise<void> => {
-  const correlationId = `${Math.floor(Date.now() / 1000)}`;
-    
   try {
     // 1- Get site verification token from onboarding API
     const {token} = await fetchOnboarding(
       "GET",
       "shopping-websites/site-verification/token",
-      correlationId
+      correlationId,
+      undefined,
+      responseHandler,
     );
       
     // 2- Store token in shop
@@ -24,13 +27,43 @@ export const runRetrievalOfVerificationTag = async (
     await fetchOnboarding(
       "POST",
       "shopping-websites/site-verification/verify",
-      correlationId
+      correlationId,
+      undefined,
+      responseHandler,
+    );
+
+    // 4- Claim website without overwrite
+    const overwriteParam = '?overwrite=false';
+    await fetchOnboarding(
+      'POST',
+      `shopping-websites/site-verification/claim${overwriteParam}`,
+      correlationId,
+      undefined,
+      responseHandler,
     );
   
     console.info('Marketing with Google - Google Verification tag has been refreshed.');
   } catch (e) {
     console.error('Marketing with Google - Google Verification tag refresh failed.', e);
-    Sentry.captureException(e);
+    scope.setTag('correlationId', correlationId);
+    Sentry.captureException(e, scope);
   }
+};
+
+const responseHandler = async (response: Response) => {
+  if (!response.ok) {
+    const error = new HttpClientError(response.statusText, response.status);
+
+    try {
+      const content = await response.text();
+      scope.setExtra('responseContent', content);
+    } catch {
+      // Do nothing
+    }
+
+    scope.setTransactionName(response.url);
+    throw error;
+  }
+  return response.json();
 };
 

--- a/psxmarketingwithgoogle.php
+++ b/psxmarketingwithgoogle.php
@@ -209,16 +209,19 @@ class PsxMarketingWithGoogle extends Module
                 $tokenPsAccounts = null;
                 $shopIdPsAccounts = null;
             }
-            Media::addJsDef([
-                'psxMktgWithGoogleApiUrl' => $env->get('PSX_MKTG_WITH_GOOGLE_API_URL'),
-                'psxMktgWithGoogleControllerLink' => $this->context->link->getAdminLink('AdminAjaxPsxMktgWithGoogle'),
-                'psxMktgWithGoogleTokenPsAccounts' => $tokenPsAccounts,
-                'psxMktgWithGoogleShopIdPsAccounts' => $shopIdPsAccounts,
-                'psxMktgWithGoogleDsnSentry' => $env->get('PSX_MKTG_WITH_GOOGLE_SENTRY_CREDENTIALS_VUE'),
-                'psxMktgWithGoogleOnProductionEnvironment' => $env->get('PSX_MKTG_WITH_GOOGLE_API_URL') === Config::PSX_MKTG_WITH_GOOGLE_API_URL,
-            ]);
-            $jsPath = (bool) $env->get('USE_LOCAL_VUE_APP') ? $this->getPathUri() . 'views/js/fetchVerificationTag.js' : $env->get('PSX_MKTG_WITH_GOOGLE_CDN_URL') . 'fetchVerificationTag.js';
-            $this->context->controller->addJs($jsPath);
+
+            if (!empty($tokenPsAccounts) && !empty($shopIdPsAccounts)) {
+                Media::addJsDef([
+                    'psxMktgWithGoogleApiUrl' => $env->get('PSX_MKTG_WITH_GOOGLE_API_URL'),
+                    'psxMktgWithGoogleControllerLink' => $this->context->link->getAdminLink('AdminAjaxPsxMktgWithGoogle'),
+                    'psxMktgWithGoogleTokenPsAccounts' => $tokenPsAccounts,
+                    'psxMktgWithGoogleShopIdPsAccounts' => $shopIdPsAccounts,
+                    'psxMktgWithGoogleDsnSentry' => $env->get('PSX_MKTG_WITH_GOOGLE_SENTRY_CREDENTIALS_VUE'),
+                    'psxMktgWithGoogleOnProductionEnvironment' => $env->get('PSX_MKTG_WITH_GOOGLE_API_URL') === Config::PSX_MKTG_WITH_GOOGLE_API_URL,
+                ]);
+                $jsPath = (bool) $env->get('USE_LOCAL_VUE_APP') ? $this->getPathUri() . 'views/js/fetchVerificationTag.js' : $env->get('PSX_MKTG_WITH_GOOGLE_CDN_URL') . 'fetchVerificationTag.js';
+                $this->context->controller->addJs($jsPath);
+            }
         }
 
         $this->context->controller->addCSS($this->getPathUri() . 'views/css/admin/menu.css');


### PR DESCRIPTION
- Do not trigger the process when we can't retrieve the shop ID or token from PS Accounts
- (Re)Claim the website after a successful verification.
- Limit the events sent to Sentry (Half of them are sent)
- Send more details to Sentry to ease debug (response content, correlation ID)