### PR TITLE
Display disapproved products even without issues linked to them

### DIFF
--- a/_dev/apps/ui/.storybook/mock/product-feed.ts
+++ b/_dev/apps/ui/.storybook/mock/product-feed.ts
@@ -1,7 +1,6 @@
 import attributesToMap from "@/store/modules/product-feed/attributes-to-map.json";
-import { OfferType } from "@/enums/product-feed/offer";
 import { RateType } from "@/enums/product-feed/rate";
-import { State, AttributesTypes } from "@/store/modules/product-feed/state";
+import { State, AttributesTypes, ProductStatus } from "@/store/modules/product-feed/state";
 import DeliveryType from '@/enums/product-feed/delivery-type';
 import { shippingPhpExport } from "./shipping-settings";
 import Categories from "@/enums/product-feed/attribute-mapping-categories";
@@ -120,12 +119,12 @@ export const productFeed: State = {
         statuses: [
           {
             destination: "Shopping",
-            status: "disapproved",
+            status: ProductStatus.Disapproved,
             countries: ["FR", "IT", "BE"],
           },
           {
             destination: "SurfacesAcrossGoogle",
-            status: "disapproved",
+            status: ProductStatus.Disapproved,
             countries: ["FR", "IT", "BE"],
           },
         ],
@@ -164,12 +163,12 @@ export const productFeed: State = {
         statuses: [
           {
             destination: "Shopping",
-            status: "disapproved",
+            status: ProductStatus.Disapproved,
             countries: ["GB"],
           },
           {
             destination: "SurfacesAcrossGoogle",
-            status: "disapproved",
+            status: ProductStatus.Disapproved,
             countries: ["GB"],
           },
         ],
@@ -245,12 +244,12 @@ export const productFeed: State = {
         statuses: [
           {
             destination: "Shopping",
-            status: "approved",
+            status: ProductStatus.Approved,
             countries: ["FR"],
           },
           {
             destination: "SurfacesAcrossGoogle",
-            status: "approved",
+            status: ProductStatus.Approved,
             countries: ["FR"],
           },
         ],
@@ -289,12 +288,12 @@ export const productFeed: State = {
         statuses: [
           {
             destination: "Shopping",
-            status: "disapproved",
+            status: ProductStatus.Disapproved,
             countries: ["BE"],
           },
           {
             destination: "SurfacesAcrossGoogle",
-            status: "disapproved",
+            status: ProductStatus.Disapproved,
             countries: ["BE"],
           },
         ],
@@ -345,12 +344,12 @@ export const productFeed: State = {
         statuses: [
           {
             destination: "Shopping",
-            status: "disapproved",
+            status: ProductStatus.Disapproved,
             countries: ["BE"],
           },
           {
             destination: "SurfacesAcrossGoogle",
-            status: "disapproved",
+            status: ProductStatus.Disapproved,
             countries: ["BE"],
           },
         ],
@@ -670,7 +669,7 @@ export const productFeedWithDisapprovedProductsButNoIssues = {
         statuses: [
           {
             destination: "SurfacesAcrossGoogle",
-            status: "disapproved",
+            status: ProductStatus.Disapproved,
             countries: ["FR"],
           },
         ],

--- a/_dev/apps/ui/src/assets/json/googleUrl.json
+++ b/_dev/apps/ui/src/assets/json/googleUrl.json
@@ -1,7 +1,6 @@
 {
   "productConfiguration" : "https://support.google.com/merchants/answer/7052112",
   "syncFailed" : "https://support.google.com/merchants/answer/188476",
-  "loginMCA" : "https://merchants.google",
   "shoppingAdsPolicies" : "https://support.google.com/merchants/answer/6149970",
   "accurateContactInformation" : "https://support.google.com/merchants/answer/6363310/follow-the-merchant-center-guidelines",
   "secureCheckoutProcess" : "https://support.google.com/merchants/answer/6150122",

--- a/_dev/apps/ui/src/assets/json/translations/en/ui.json
+++ b/_dev/apps/ui/src/assets/json/translations/en/ui.json
@@ -721,7 +721,8 @@
         "xResults": "{0} results",
         "perPageLabel": "Show:",
         "goToLabel": "Go to page:",
-        "editX": "Edit {0}"
+        "editX": "Edit {0}",
+        "noReasonFallback": "*Not provided, check [account errors on Merchant Center]({0})[:target=\"_blank\"].*"
       },
       "errorReason": {
         "fieldXMissing": "A required field is missing: {0}",

--- a/_dev/apps/ui/src/assets/json/translations/en/ui.json
+++ b/_dev/apps/ui/src/assets/json/translations/en/ui.json
@@ -722,7 +722,7 @@
         "perPageLabel": "Show:",
         "goToLabel": "Go to page:",
         "editX": "Edit {0}",
-        "noReasonFallback": "*Not provided, check [account errors on Merchant Center]({0})[:target=\"_blank\"].*"
+        "noReasonFallback": "*Not provided, check [account errors on your Merchant Center]({0})[:target=\"_blank\"].*"
       },
       "errorReason": {
         "fieldXMissing": "A required field is missing: {0}",

--- a/_dev/apps/ui/src/components/product-feed-page/product-feed-table-status-details-row.spec.ts
+++ b/_dev/apps/ui/src/components/product-feed-page/product-feed-table-status-details-row.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * @jest-environment jsdom
+ */
+import Vuex from 'vuex';
+
+// Import this file first to init mock on window
+import {mount, MountOptions, Wrapper} from '@vue/test-utils';
+import {BTd} from 'bootstrap-vue';
+import {ProductInfos, ProductStatus} from '@/store/modules/product-feed/state';
+import config, {
+  localVue, cloneStore, addBootstrapToVue, addShowdownToVue,
+} from '@/../tests/init';
+
+import productFeedTableStatusDetailsRowVue from './product-feed-table-status-details-row.vue';
+
+describe('product-feed-table-status-details-row.vue', () => {
+  const buildWrapper = (
+    options: MountOptions<any> = {},
+  ) => {
+    addBootstrapToVue();
+    addShowdownToVue();
+    const store = cloneStore();
+
+    return mount(productFeedTableStatusDetailsRowVue, {
+      localVue,
+      store: new Vuex.Store(store),
+      ...config,
+      ...options,
+    });
+  };
+
+  it('displays products errors', () => {
+    // Arrange
+    const product: ProductInfos = {
+      id: '7990',
+      attribute: '0',
+      name: 'Psykokwak',
+      language: 'fr',
+      statuses: [
+        {
+          destination: 'Shopping',
+          status: ProductStatus.Disapproved,
+          countries: ['FR', 'IT', 'BE'],
+        },
+      ],
+      issues: [
+        {
+          code: 'policy_enforcement_account_disapproval',
+          servability: 'disapproved',
+          resolution: 'merchant_action',
+          destination: 'Shopping',
+          description: 'Suspended account for policy violation',
+          detail:
+            'Remove products that violate our policies, or request a manual review',
+          documentation:
+            'https://support.google.com/merchants/answer/2948694',
+          applicableCountries: ['BE'],
+        },
+      ],
+    };
+
+    // Act
+    const wrapper = buildWrapper({
+      propsData: {
+        product,
+        status: product.statuses[0],
+        indexStatus: 0,
+      },
+    });
+
+    // Assert
+    const cells = wrapper.findAllComponents(BTd);
+    expect(cells.length).toBe(7);
+
+    expect(cells.at(0).text()).toEqual('7990');
+    expect(cells.at(1).text()).toEqual('Psykokwak');
+
+    const countrySpans = cells.at(2).findAll('span');
+    expect(countrySpans.length).toEqual(3);
+    expect(countrySpans.at(0).text()).toEqual('FR');
+    expect(countrySpans.at(1).text()).toEqual('IT');
+    expect(countrySpans.at(2).text()).toEqual('BE');
+
+    expect(cells.at(3).text()).toEqual('fr');
+    expect(cells.at(4).text()).toEqual('disapproved');
+
+    const errorsList = cells.at(5).findAll('li');
+    expect(errorsList.length).toEqual(1);
+    expect(errorsList.at(0).text()).toEqual('Suspended account for policy violation');
+
+    expect(cells.at(6).text()).toEqual('Shopping Ads');
+  });
+
+  it('suggests to the merchant to open the GMC website to check the errors on the account level', () => {
+    // Arrange
+    const product: ProductInfos = {
+      id: '7990',
+      attribute: '0',
+      name: 'Psykokwak',
+      language: 'fr',
+      statuses: [
+        {
+          destination: 'Shopping',
+          status: ProductStatus.Disapproved,
+          countries: ['FR', 'IT', 'BE'],
+        },
+      ],
+    };
+
+    // Act
+    const wrapper = buildWrapper({
+      propsData: {
+        product,
+        status: product.statuses[0],
+        indexStatus: 0,
+      },
+    });
+
+    // Assert
+    const cells = wrapper.findAllComponents(BTd);
+    expect(cells.length).toBe(7);
+
+    expect(cells.at(0).text()).toEqual('7990');
+    expect(cells.at(1).text()).toEqual('Psykokwak');
+
+    const countrySpans = cells.at(2).findAll('span');
+    expect(countrySpans.length).toEqual(3);
+    expect(countrySpans.at(0).text()).toEqual('FR');
+    expect(countrySpans.at(1).text()).toEqual('IT');
+    expect(countrySpans.at(2).text()).toEqual('BE');
+
+    expect(cells.at(3).text()).toEqual('fr');
+    expect(cells.at(4).text()).toEqual('disapproved');
+
+    const errorsList = cells.at(5).findAll('li');
+    expect(errorsList.length).toEqual(0);
+    expect(cells.at(5).text()).toEqual('Not provided, check account errors on your Merchant Center.');
+
+    expect(cells.at(6).text()).toEqual('Shopping Ads');
+  });
+
+  it('merges some cells with the upper line when statuses between for different destinations are the same', () => {
+    // Arrange
+    const product: ProductInfos = {
+      id: '7990',
+      attribute: '0',
+      name: 'Psykokwak',
+      language: 'fr',
+      statuses: [
+        {
+          destination: 'Shopping',
+          status: ProductStatus.Disapproved,
+          countries: ['FR', 'IT', 'BE'],
+        },
+        {
+          destination: 'SurfacesAcrossGoogle',
+          status: ProductStatus.Disapproved,
+          countries: ['FR', 'IT', 'BE'],
+        },
+      ],
+      issues: [
+        {
+          // Content unecessary for the purpose of this test
+        },
+        {
+          code: 'policy_enforcement_account_disapproval',
+          servability: 'disapproved',
+          resolution: 'merchant_action',
+          destination: 'SurfacesAcrossGoogle',
+          description: 'Another error',
+          detail:
+                'Remove products that violate our policies, or request a manual review',
+          documentation:
+                'https://support.google.com/merchants/answer/2948694',
+          applicableCountries: ['BE'],
+        },
+      ],
+    };
+
+    // Act
+    const wrapper = buildWrapper({
+      propsData: {
+        product,
+        status: product.statuses[1],
+        indexStatus: 1,
+      },
+    });
+
+    // Assert
+    const cells = wrapper.findAllComponents(BTd);
+    expect(cells.length).toBe(2);
+    expect(cells.at(0).text()).toEqual('Another error');
+    expect(cells.at(1).text()).toEqual('Enhanced Free Listings');
+  });
+});

--- a/_dev/apps/ui/src/components/product-feed-page/product-feed-table-status-details-row.vue
+++ b/_dev/apps/ui/src/components/product-feed-page/product-feed-table-status-details-row.vue
@@ -27,17 +27,14 @@
       :rowspan="countriesAndStatusAreTheSame ? product.statuses.length : 0"
       v-if="!indexStatus || !countriesAndStatusAreTheSame"
     >
-      <span
+      <b-badge
         v-for="(country, indexCountry) in status.countries"
         :key="indexCountry"
+        variant="primary"
+        class="ps_gs-fz-12 mb-1 mr-1"
       >
-        <b-badge
-          variant="primary"
-          class="ps_gs-fz-12 mb-1 mr-1"
-        >
-          {{ country }}
-        </b-badge>
-      </span>
+        {{ country }}
+      </b-badge>
     </b-td>
     <b-td
       class="align-top"

--- a/_dev/apps/ui/src/store/modules/product-feed/state.ts
+++ b/_dev/apps/ui/src/store/modules/product-feed/state.ts
@@ -60,9 +60,16 @@ export interface ProductInfos {
  name: string;
  attribute: string;
  language: string;
- issues? : contentApi.Schema$ProductStatusItemLevelIssue[];
- statuses? : Array<object>;
+ statuses: ProductInfosStatus[];
+ issues?: contentApi.Schema$ProductStatusItemLevelIssue[];
 }
+
+export type ProductInfosStatus = {
+  destination: string;
+  status: ProductStatus;
+  countries: string[];
+}
+
 export interface ProductsDatas {
   items: ProductInfos[];
 }
@@ -131,7 +138,7 @@ export interface State {
   attributeMapping: AttributeResponseFromAPI;
 }
 
-export enum ProductStatues {
+export enum ProductStatus {
   Disapproved = 'disapproved',
   Pending = 'pending',
   Approved = 'approved',

--- a/_dev/apps/ui/stories/product-feed-table-status-details.stories.ts
+++ b/_dev/apps/ui/stories/product-feed-table-status-details.stories.ts
@@ -95,321 +95,306 @@ TableStatusDetails.parameters = {
           ctx.json({
             nextToken: "6d5774328a7deb62",
             results: [
-                {
-                    "id": "7990",
-                    "attribute": "0",
-                    "name": "Psykokwak",
-                    "language": "fr",
-                    "statuses": [
-                        {
-                            "destination": "Shopping",
-                            "status": "disapproved",
-                            "countries": [
-                                "FR",
-                                "IT",
-                                "BE"
-                            ]
-                        },
-                        {
-                            "destination": "SurfacesAcrossGoogle",
-                            "status": "disapproved",
-                            "countries": [
-                                "FR",
-                                "IT",
-                                "BE"
-                            ]
-                        }
-                    ],
-                    "issues": [
-                        {
-                            "code": "invalid_upc",
-                            "servability": "disapproved",
-                            "resolution": "merchant_action",
-                            "attributeName": "gtin",
-                            "destination": "SurfacesAcrossGoogle",
-                            "description": "Invalid value [gtin]",
-                            "detail": "Use your product's globally valid GTIN",
-                            "documentation": "https://support.google.com/merchants/answer/6239388",
-                            "applicableCountries": [
-                                "FR",
-                                "IT",
-                                "BE"
-                            ]
-                        },
-                        {
-                            "code": "policy_enforcement_account_disapproval",
-                            "servability": "disapproved",
-                            "resolution": "merchant_action",
-                            "destination": "Shopping",
-                            "description": "Suspended account for policy violation",
-                            "detail": "Remove products that violate our policies, or request a manual review",
-                            "documentation": "https://support.google.com/merchants/answer/2948694",
-                            "applicableCountries": [
-                                "BE"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "id": "8028",
-                    "attribute": "0",
-                    "name": "Fantominus",
-                    "language": "en",
-                    "statuses": [
-                        {
-                            "destination": "Shopping",
-                            "status": "disapproved",
-                            "countries": [
-                                "GB"
-                            ]
-                        },
-                        {
-                            "destination": "SurfacesAcrossGoogle",
-                            "status": "disapproved",
-                            "countries": [
-                                "GB"
-                            ]
-                        }
-                    ],
-                    "issues": [
-                        {
-                            "code": "language_mismatch",
-                            "servability": "unaffected",
-                            "resolution": "merchant_action",
-                            "destination": "Shopping",
-                            "description": "Incorrect language",
-                            "detail": "Use a supported language for the country of sale",
-                            "documentation": "https://support.google.com/merchants/answer/6101164",
-                            "applicableCountries": [
-                                "GB"
-                            ]
-                        },
-                        {
-                            "code": "hard_goods_missing_2_out_of_3_identifiers",
-                            "servability": "demoted",
-                            "resolution": "merchant_action",
-                            "destination": "Shopping",
-                            "description": "Limited performance due to missing identifiers [gtin, mpn, brand]",
-                            "detail": "Add a brand and either a GTIN or MPN. If this product is one-of-a-kind or vintage, you don’t need to add an identifier.",
-                            "documentation": "https://support.google.com/merchants/answer/6098295",
-                            "applicableCountries": [
-                                "GB"
-                            ]
-                        },
-                        {
-                            "code": "price_mismatch",
-                            "servability": "disapproved",
-                            "resolution": "merchant_action",
-                            "attributeName": "price",
-                            "destination": "Shopping",
-                            "description": "Mismatched value (page crawl) [price]",
-                            "detail": "Update your product's price in your product data to match the price on your landing page",
-                            "documentation": "https://support.google.com/merchants/answer/6098334",
-                            "applicableCountries": [
-                                "GB"
-                            ]
-                        },
-                        {
-                            "code": "pending_initial_policy_review_shopping_ads",
-                            "servability": "disapproved",
-                            "resolution": "pending_processing",
-                            "destination": "Shopping",
-                            "description": "Pending initial review",
-                            "detail": "Please wait up to 3 business days for the review to be completed",
-                            "documentation": "https://support.google.com/merchants/answer/2948694",
-                            "applicableCountries": [
-                                "GB"
-                            ]
-                        },
-                        {
-                            "code": "missing_shipping",
-                            "servability": "disapproved",
-                            "resolution": "merchant_action",
-                            "attributeName": "shipping",
-                            "destination": "Shopping",
-                            "description": "Missing value [shipping]",
-                            "detail": "Add shipping costs for your product",
-                            "documentation": "https://support.google.com/merchants/answer/6239383",
-                            "applicableCountries": [
-                                "GB"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "id": "7961",
-                    "attribute": "4",
-                    "name": "Pikachu",
-                    "language": "fr",
-                    "statuses": [
-                        {
-                            "destination": "Shopping",
-                            "status": "approved",
-                            "countries": [
-                                "FR"
-                            ]
-                        },
-                        {
-                            "destination": "SurfacesAcrossGoogle",
-                            "status": "approved",
-                            "countries": [
-                                "FR"
-                            ]
-                        }
-                    ],
-                    "issues": [
-                        {
-                            "code": "language_mismatch",
-                            "servability": "unaffected",
-                            "resolution": "merchant_action",
-                            "destination": "Shopping",
-                            "description": "Incorrect language",
-                            "detail": "Use a supported language for the country of sale",
-                            "documentation": "https://support.google.com/merchants/answer/6101164",
-                            "applicableCountries": [
-                                "FR"
-                            ]
-                        },
-                        {
-                            "code": "hard_goods_missing_2_out_of_3_identifiers",
-                            "servability": "demoted",
-                            "resolution": "merchant_action",
-                            "destination": "Shopping",
-                            "description": "Limited performance due to missing identifiers [gtin, mpn, brand]",
-                            "detail": "Add a brand and either a GTIN or MPN. If this product is one-of-a-kind or vintage, you don’t need to add an identifier.",
-                            "documentation": "https://support.google.com/merchants/answer/6098295",
-                            "applicableCountries": [
-                                "FR"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "id": "7961",
-                    "attribute": "4",
-                    "name": "Pikachu",
-                    "language": "it",
-                    "statuses": [
-                        {
-                            "destination": "Shopping",
-                            "status": "disapproved",
-                            "countries": [
-                                "BE"
-                            ]
-                        },
-                        {
-                            "destination": "SurfacesAcrossGoogle",
-                            "status": "disapproved",
-                            "countries": [
-                                "BE"
-                            ]
-                        }
-                    ],
-                    "issues": [
-                        {
-                            "code": "language_mismatch",
-                            "servability": "unaffected",
-                            "resolution": "merchant_action",
-                            "destination": "Shopping",
-                            "description": "Incorrect language",
-                            "detail": "Use a supported language for the country of sale",
-                            "documentation": "https://support.google.com/merchants/answer/6101164",
-                            "applicableCountries": [
-                                "FR",
-                                "IT"
-                            ]
-                        },
-                        {
-                            "code": "hard_goods_missing_2_out_of_3_identifiers",
-                            "servability": "demoted",
-                            "resolution": "merchant_action",
-                            "destination": "Shopping",
-                            "description": "Limited performance due to missing identifiers [gtin, mpn, brand]",
-                            "detail": "Add a brand and either a GTIN or MPN. If this product is one-of-a-kind or vintage, you don’t need to add an identifier.",
-                            "documentation": "https://support.google.com/merchants/answer/6098295",
-                            "applicableCountries": [
-                                "FR",
-                                "IT"
-                            ]
-                        },
-                        {
-                            "code": "policy_enforcement_account_disapproval",
-                            "servability": "disapproved",
-                            "resolution": "merchant_action",
-                            "destination": "Shopping",
-                            "description": "Suspended account for policy violation",
-                            "detail": "Remove products that violate our policies, or request a manual review",
-                            "documentation": "https://support.google.com/merchants/answer/2948694",
-                            "applicableCountries": [
-                                "BE"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "id": "7961",
-                    "attribute": "3",
-                    "name": "Pikachu",
-                    "language": "de",
-                    "statuses": [
-                        {
-                            "destination": "Shopping",
-                            "status": "disapproved",
-                            "countries": [
-                                "BE"
-                            ]
-                        },
-                        {
-                            "destination": "SurfacesAcrossGoogle",
-                            "status": "disapproved",
-                            "countries": [
-                                "BE"
-                            ]
-                        }
-                    ],
-                    "issues": [
-                        {
-                            "code": "language_mismatch",
-                            "servability": "unaffected",
-                            "resolution": "merchant_action",
-                            "destination": "Shopping",
-                            "description": "Incorrect language",
-                            "detail": "Use a supported language for the country of sale",
-                            "documentation": "https://support.google.com/merchants/answer/6101164",
-                            "applicableCountries": [
-                                "FR",
-                                "IT"
-                            ]
-                        },
-                        {
-                            "code": "hard_goods_missing_2_out_of_3_identifiers",
-                            "servability": "demoted",
-                            "resolution": "merchant_action",
-                            "destination": "Shopping",
-                            "description": "Limited performance due to missing identifiers [gtin, mpn, brand]",
-                            "detail": "Add a brand and either a GTIN or MPN. If this product is one-of-a-kind or vintage, you don’t need to add an identifier.",
-                            "documentation": "https://support.google.com/merchants/answer/6098295",
-                            "applicableCountries": [
-                                "FR",
-                                "IT"
-                            ]
-                        },
-                        {
-                            "code": "policy_enforcement_account_disapproval",
-                            "servability": "disapproved",
-                            "resolution": "merchant_action",
-                            "destination": "Shopping",
-                            "description": "Suspended account for policy violation",
-                            "detail": "Remove products that violate our policies, or request a manual review",
-                            "documentation": "https://support.google.com/merchants/answer/2948694",
-                            "applicableCountries": [
-                                "BE"
-                            ]
-                        }
-                    ]
-                }
-                
-            ]
+              {
+                id: "7939",
+                attribute: "0",
+                name: "Venusaur",
+                language: "en",
+                statuses: [
+                  {
+                    destination: "Shopping",
+                    status: "approved",
+                    countries: ["FR", "IT", "BE"],
+                  },
+                  {
+                    destination: "SurfacesAcrossGoogle",
+                    status: "approved",
+                    countries: ["FR", "IT", "BE"],
+                  },
+                ],
+              },
+              {
+                id: "7990",
+                attribute: "0",
+                name: "Psykokwak",
+                language: "fr",
+                statuses: [
+                  {
+                    destination: "Shopping",
+                    status: "disapproved",
+                    countries: ["FR", "IT", "BE"],
+                  },
+                  {
+                    destination: "SurfacesAcrossGoogle",
+                    status: "disapproved",
+                    countries: ["FR", "IT", "BE"],
+                  },
+                ],
+                issues: [
+                  {
+                    code: "invalid_upc",
+                    servability: "disapproved",
+                    resolution: "merchant_action",
+                    attributeName: "gtin",
+                    destination: "SurfacesAcrossGoogle",
+                    description: "Invalid value [gtin]",
+                    detail: "Use your product's globally valid GTIN",
+                    documentation:
+                      "https://support.google.com/merchants/answer/6239388",
+                    applicableCountries: ["FR", "IT", "BE"],
+                  },
+                  {
+                    code: "policy_enforcement_account_disapproval",
+                    servability: "disapproved",
+                    resolution: "merchant_action",
+                    destination: "Shopping",
+                    description: "Suspended account for policy violation",
+                    detail:
+                      "Remove products that violate our policies, or request a manual review",
+                    documentation:
+                      "https://support.google.com/merchants/answer/2948694",
+                    applicableCountries: ["BE"],
+                  },
+                ],
+              },
+              {
+                id: "8028",
+                attribute: "0",
+                name: "Fantominus",
+                language: "en",
+                statuses: [
+                  {
+                    destination: "Shopping",
+                    status: "disapproved",
+                    countries: ["GB"],
+                  },
+                  {
+                    destination: "SurfacesAcrossGoogle",
+                    status: "disapproved",
+                    countries: ["GB"],
+                  },
+                ],
+                issues: [
+                  {
+                    code: "language_mismatch",
+                    servability: "unaffected",
+                    resolution: "merchant_action",
+                    destination: "Shopping",
+                    description: "Incorrect language",
+                    detail: "Use a supported language for the country of sale",
+                    documentation:
+                      "https://support.google.com/merchants/answer/6101164",
+                    applicableCountries: ["GB"],
+                  },
+                  {
+                    code: "hard_goods_missing_2_out_of_3_identifiers",
+                    servability: "demoted",
+                    resolution: "merchant_action",
+                    destination: "Shopping",
+                    description:
+                      "Limited performance due to missing identifiers [gtin, mpn, brand]",
+                    detail:
+                      "Add a brand and either a GTIN or MPN. If this product is one-of-a-kind or vintage, you don’t need to add an identifier.",
+                    documentation:
+                      "https://support.google.com/merchants/answer/6098295",
+                    applicableCountries: ["GB"],
+                  },
+                  {
+                    code: "price_mismatch",
+                    servability: "disapproved",
+                    resolution: "merchant_action",
+                    attributeName: "price",
+                    destination: "Shopping",
+                    description: "Mismatched value (page crawl) [price]",
+                    detail:
+                      "Update your product's price in your product data to match the price on your landing page",
+                    documentation:
+                      "https://support.google.com/merchants/answer/6098334",
+                    applicableCountries: ["GB"],
+                  },
+                  {
+                    code: "pending_initial_policy_review_shopping_ads",
+                    servability: "disapproved",
+                    resolution: "pending_processing",
+                    destination: "Shopping",
+                    description: "Pending initial review",
+                    detail:
+                      "Please wait up to 3 business days for the review to be completed",
+                    documentation:
+                      "https://support.google.com/merchants/answer/2948694",
+                    applicableCountries: ["GB"],
+                  },
+                  {
+                    code: "missing_shipping",
+                    servability: "disapproved",
+                    resolution: "merchant_action",
+                    attributeName: "shipping",
+                    destination: "Shopping",
+                    description: "Missing value [shipping]",
+                    detail: "Add shipping costs for your product",
+                    documentation:
+                      "https://support.google.com/merchants/answer/6239383",
+                    applicableCountries: ["GB"],
+                  },
+                ],
+              },
+              {
+                id: "7961",
+                attribute: "4",
+                name: "Pikachu",
+                language: "fr",
+                statuses: [
+                  {
+                    destination: "Shopping",
+                    status: "approved",
+                    countries: ["FR"],
+                  },
+                  {
+                    destination: "SurfacesAcrossGoogle",
+                    status: "approved",
+                    countries: ["FR"],
+                  },
+                ],
+                issues: [
+                  {
+                    code: "language_mismatch",
+                    servability: "unaffected",
+                    resolution: "merchant_action",
+                    destination: "Shopping",
+                    description: "Incorrect language",
+                    detail: "Use a supported language for the country of sale",
+                    documentation:
+                      "https://support.google.com/merchants/answer/6101164",
+                    applicableCountries: ["FR"],
+                  },
+                  {
+                    code: "hard_goods_missing_2_out_of_3_identifiers",
+                    servability: "demoted",
+                    resolution: "merchant_action",
+                    destination: "Shopping",
+                    description:
+                      "Limited performance due to missing identifiers [gtin, mpn, brand]",
+                    detail:
+                      "Add a brand and either a GTIN or MPN. If this product is one-of-a-kind or vintage, you don’t need to add an identifier.",
+                    documentation:
+                      "https://support.google.com/merchants/answer/6098295",
+                    applicableCountries: ["FR"],
+                  },
+                ],
+              },
+              {
+                id: "7961",
+                attribute: "4",
+                name: "Pikachu",
+                language: "it",
+                statuses: [
+                  {
+                    destination: "Shopping",
+                    status: "disapproved",
+                    countries: ["BE"],
+                  },
+                  {
+                    destination: "SurfacesAcrossGoogle",
+                    status: "disapproved",
+                    countries: ["BE"],
+                  },
+                ],
+                issues: [
+                  {
+                    code: "language_mismatch",
+                    servability: "unaffected",
+                    resolution: "merchant_action",
+                    destination: "Shopping",
+                    description: "Incorrect language",
+                    detail: "Use a supported language for the country of sale",
+                    documentation:
+                      "https://support.google.com/merchants/answer/6101164",
+                    applicableCountries: ["FR", "IT"],
+                  },
+                  {
+                    code: "hard_goods_missing_2_out_of_3_identifiers",
+                    servability: "demoted",
+                    resolution: "merchant_action",
+                    destination: "Shopping",
+                    description:
+                      "Limited performance due to missing identifiers [gtin, mpn, brand]",
+                    detail:
+                      "Add a brand and either a GTIN or MPN. If this product is one-of-a-kind or vintage, you don’t need to add an identifier.",
+                    documentation:
+                      "https://support.google.com/merchants/answer/6098295",
+                    applicableCountries: ["FR", "IT"],
+                  },
+                  {
+                    code: "policy_enforcement_account_disapproval",
+                    servability: "disapproved",
+                    resolution: "merchant_action",
+                    destination: "Shopping",
+                    description: "Suspended account for policy violation",
+                    detail:
+                      "Remove products that violate our policies, or request a manual review",
+                    documentation:
+                      "https://support.google.com/merchants/answer/2948694",
+                    applicableCountries: ["BE"],
+                  },
+                ],
+              },
+              {
+                id: "7961",
+                attribute: "3",
+                name: "Pikachu",
+                language: "de",
+                statuses: [
+                  {
+                    destination: "Shopping",
+                    status: "disapproved",
+                    countries: ["BE"],
+                  },
+                  {
+                    destination: "SurfacesAcrossGoogle",
+                    status: "disapproved",
+                    countries: ["BE"],
+                  },
+                ],
+                issues: [
+                  {
+                    code: "language_mismatch",
+                    servability: "unaffected",
+                    resolution: "merchant_action",
+                    destination: "Shopping",
+                    description: "Incorrect language",
+                    detail: "Use a supported language for the country of sale",
+                    documentation:
+                      "https://support.google.com/merchants/answer/6101164",
+                    applicableCountries: ["FR", "IT"],
+                  },
+                  {
+                    code: "hard_goods_missing_2_out_of_3_identifiers",
+                    servability: "demoted",
+                    resolution: "merchant_action",
+                    destination: "Shopping",
+                    description:
+                      "Limited performance due to missing identifiers [gtin, mpn, brand]",
+                    detail:
+                      "Add a brand and either a GTIN or MPN. If this product is one-of-a-kind or vintage, you don’t need to add an identifier.",
+                    documentation:
+                      "https://support.google.com/merchants/answer/6098295",
+                    applicableCountries: ["FR", "IT"],
+                  },
+                  {
+                    code: "policy_enforcement_account_disapproval",
+                    servability: "disapproved",
+                    resolution: "merchant_action",
+                    destination: "Shopping",
+                    description: "Suspended account for policy violation",
+                    detail:
+                      "Remove products that violate our policies, or request a manual review",
+                    documentation:
+                      "https://support.google.com/merchants/answer/2948694",
+                    applicableCountries: ["BE"],
+                  },
+                ],
+              },
+            ],
           })
         );
       }),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6768917/224702621-aaec2f7d-0c81-4a72-9369-40ec272fa130.png)

* Switch component _dev/apps/ui/src/components/product-feed-page/product-feed-table-status-details-row.vue on TypeScript
* Add related types
* Add a default message recommending to the merchant to check its account errors, with a direct link