### PR TITLE
Use latest version of PHPStan

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -46,30 +46,43 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['1.7.5.0', '1.7.7.0', 'latest']
+        prestashop_version: [
+          "https://github.com/PrestaShop/PrestaShop/releases/download/8.0.0/prestashop_8.0.0.zip",
+          "https://github.com/PrestaShop/PrestaShop/releases/download/1.7.7.0/prestashop_1.7.7.0.zip",
+          "https://github.com/PrestaShop/PrestaShop/releases/download/1.7.5.0/prestashop_1.7.5.0.zip",
+        ]
     steps:
+      - name: Download PrestaShop code source
+        run: |
+          wget -O /tmp/prestashop.zip ${{ matrix.prestashop_version }}
+          unzip -o /tmp/prestashop.zip -d /tmp
+          unzip -o /tmp/prestashop.zip -d /tmp/prestashop
+      - name: Setup PHP with tools
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: vendor
-          key: php-${{ hashFiles('composer.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.composer/cache
           key: php-composer-cache
 
       - run: composer install
 
-      - name: Pull PrestaShop files (Tag ${{ matrix.presta-versions }})
-        run: docker run -tid --rm -v ps-volume:/var/www/html --name temp-ps prestashop/prestashop:${{ matrix.presta-versions }}
-
-      - name : Run PHPStan
-        run: docker run --rm --volumes-from temp-ps -v $PWD:/web/module -e _PS_ROOT_DIR_=/var/www/html --workdir=/web/module phpstan/phpstan:0.12 analyse --configuration=/web/module/tests/phpstan/phpstan.neon --error-format github
+      - name: Run PHPStan
+        env:
+          _PS_ROOT_DIR_: /tmp/prestashop
+        run: vendor/bin/phpstan analyze -c tests/phpstan/phpstan.neon
 
   phpunit:
     name: PHPUnit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,14 +47,14 @@ jobs:
     strategy:
       matrix:
         prestashop_version: [
-          "https://github.com/PrestaShop/PrestaShop/releases/download/8.0.0/prestashop_8.0.0.zip",
-          "https://github.com/PrestaShop/PrestaShop/releases/download/1.7.7.0/prestashop_1.7.7.0.zip",
-          "https://github.com/PrestaShop/PrestaShop/releases/download/1.7.5.0/prestashop_1.7.5.0.zip",
+          "8.0.0",
+          "1.7.7.0",
+          "1.7.5.0",
         ]
     steps:
       - name: Download PrestaShop code source
         run: |
-          wget -O /tmp/prestashop.zip ${{ matrix.prestashop_version }}
+          wget -O /tmp/prestashop.zip https://github.com/PrestaShop/PrestaShop/releases/download/${{ matrix.prestashop_version }}/prestashop_${{ matrix.prestashop_version }}.zip
           unzip -o /tmp/prestashop.zip -d /tmp
           unzip -o /tmp/prestashop.zip -d /tmp/prestashop
       - name: Setup PHP with tools
@@ -82,7 +82,7 @@ jobs:
       - name: Run PHPStan
         env:
           _PS_ROOT_DIR_: /tmp/prestashop
-        run: vendor/bin/phpstan analyze -c tests/phpstan/phpstan.neon
+        run: vendor/bin/phpstan analyze -c tests/phpstan/phpstan.neon --error-format github
 
   phpunit:
     name: PHPUnit

--- a/classes/Database/Uninstaller.php
+++ b/classes/Database/Uninstaller.php
@@ -32,13 +32,6 @@ class Uninstaller
     public const CLASS_NAME = 'Uninstaller';
 
     /**
-     * @var array
-     */
-    private $errors = [];
-
-    private $module;
-
-    /**
      * @var TabRepository
      */
     private $tabRepository;
@@ -54,12 +47,10 @@ class Uninstaller
     private $errorHandler;
 
     public function __construct(
-        \PsxMarketingWithGoogle $module,
         TabRepository $tabRepository,
         Segment $segment,
         ErrorHandler $errorHandler
     ) {
-        $this->module = $module;
         $this->tabRepository = $tabRepository;
         $this->segment = $segment;
         $this->errorHandler = $errorHandler;
@@ -113,7 +104,6 @@ class Uninstaller
                 $e->getCode(),
                 false
             );
-            $this->errors[] = $this->module->l('Failed to uninstall database tables', self::CLASS_NAME);
 
             return false;
         }
@@ -155,7 +145,6 @@ class Uninstaller
                 $e->getCode(),
                 false
             );
-            $this->errors[] = $this->module->l('Failed to uninstall database tables', self::CLASS_NAME);
 
             return false;
         }

--- a/classes/Provider/CarrierDataProvider.php
+++ b/classes/Provider/CarrierDataProvider.php
@@ -26,7 +26,6 @@ use Language;
 use PrestaShop\Module\PsxMarketingWithGoogle\Adapter\ConfigurationAdapter;
 use PrestaShop\Module\PsxMarketingWithGoogle\Builder\CarrierBuilder;
 use PrestaShop\Module\PsxMarketingWithGoogle\DTO\Carrier as DTOCarrier;
-use PrestaShop\Module\PsxMarketingWithGoogle\Repository\CarrierRepository;
 use RangePrice;
 use RangeWeight;
 
@@ -42,19 +41,12 @@ class CarrierDataProvider
      */
     private $carrierBuilder;
 
-    /**
-     * @var CarrierRepository
-     */
-    private $carrierRepository;
-
     public function __construct(
         ConfigurationAdapter $configurationAdapter,
-        CarrierBuilder $carrierBuilder,
-        CarrierRepository $carrierRepository
+        CarrierBuilder $carrierBuilder
     ) {
         $this->configurationAdapter = $configurationAdapter;
         $this->carrierBuilder = $carrierBuilder;
-        $this->carrierRepository = $carrierRepository;
     }
 
     public function getFormattedData(): array

--- a/classes/Repository/CarrierRepository.php
+++ b/classes/Repository/CarrierRepository.php
@@ -21,29 +21,11 @@
 namespace PrestaShop\Module\PsxMarketingWithGoogle\Repository;
 
 use Carrier;
-use Context;
-use Db;
 use RangePrice;
 use RangeWeight;
 
 class CarrierRepository
 {
-    /**
-     * @var Db
-     */
-    private $db;
-
-    /**
-     * @var Context
-     */
-    private $context;
-
-    public function __construct(Db $db, Context $context)
-    {
-        $this->db = $db;
-        $this->context = $context;
-    }
-
     public function getCarriers(int $langId): array
     {
         $carriers = Carrier::getCarriers($langId, false, false, false, null, Carrier::ALL_CARRIERS);

--- a/classes/Repository/ModuleRepository.php
+++ b/classes/Repository/ModuleRepository.php
@@ -42,7 +42,7 @@ class ModuleRepository
      */
     public function getModuleVersion()
     {
-        /** @var Module $module */
+        /** @var Module|null $module */
         $module = Module::getInstanceByName($this->moduleName);
 
         if (!empty($module)) {
@@ -105,7 +105,7 @@ class ModuleRepository
     {
         $context = Context::getContext();
         $hooks = [];
-        /** @var Module $moduleInstance */
+        /** @var Module|null $moduleInstance */
         $moduleInstance = Module::getInstanceByName($this->moduleName);
 
         if (empty($moduleInstance)) {

--- a/classes/Repository/StateRepository.php
+++ b/classes/Repository/StateRepository.php
@@ -20,7 +20,6 @@
 
 namespace PrestaShop\Module\PsxMarketingWithGoogle\Repository;
 
-use Context;
 use Db;
 use DbQuery;
 
@@ -31,17 +30,11 @@ class StateRepository
      */
     private $db;
 
-    /**
-     * @var Context
-     */
-    private $context;
-
     private $stateIsoCodeCache = [];
 
-    public function __construct(Db $db, Context $context)
+    public function __construct(Db $db)
     {
         $this->db = $db;
-        $this->context = $context;
     }
 
     private function getBaseQuery(): DbQuery

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     },
     "require-dev": {
         "prestashop/php-dev-tools": "^4.2",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^8.5",
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "853470926aa57aa7cb48c361581258b9",
+    "content-hash": "2433c6efefe83de43272ae43018e9064",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -2135,6 +2135,68 @@
             },
             "abandoned": true,
             "time": "2020-10-14T08:32:19+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.10.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "b10ceb526d9607903c5b2673f1fc8775dbe48975"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b10ceb526d9607903c5b2673f1fc8775dbe48975",
+                "reference": "b10ceb526d9607903c5b2673f1fc8775dbe48975",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-03-16T15:24:20+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/config/admin/installer.yml
+++ b/config/admin/installer.yml
@@ -11,7 +11,6 @@ services:
     class: PrestaShop\Module\PsxMarketingWithGoogle\Database\Uninstaller
     public: true
     arguments:
-      - '@psxmarketingwithgoogle'
       - '@PrestaShop\Module\PsxMarketingWithGoogle\Repository\TabRepository'
       - '@PrestaShop\Module\PsxMarketingWithGoogle\Tracker\Segment'
       - '@PrestaShop\Module\PsxMarketingWithGoogle\Handler\ErrorHandler'

--- a/config/admin/provider.yml
+++ b/config/admin/provider.yml
@@ -5,7 +5,6 @@ services:
     arguments:
       - '@PrestaShop\Module\PsxMarketingWithGoogle\Adapter\ConfigurationAdapter'
       - '@PrestaShop\Module\PsxMarketingWithGoogle\Builder\CarrierBuilder'
-      - '@PrestaShop\Module\PsxMarketingWithGoogle\Repository\CarrierRepository'
 
   PrestaShop\Module\PsxMarketingWithGoogle\Provider\GoogleTagProvider:
     class: PrestaShop\Module\PsxMarketingWithGoogle\Provider\GoogleTagProvider

--- a/config/common/repository.yml
+++ b/config/common/repository.yml
@@ -7,9 +7,6 @@ services:
   PrestaShop\Module\PsxMarketingWithGoogle\Repository\CarrierRepository:
     class: PrestaShop\Module\PsxMarketingWithGoogle\Repository\CarrierRepository
     public: true
-    arguments:
-      - '@psxmarketingwithgoogle.db'
-      - '@psxmarketingwithgoogle.context'
 
   PrestaShop\Module\PsxMarketingWithGoogle\Repository\AttributesRepository:
     class: PrestaShop\Module\PsxMarketingWithGoogle\Repository\AttributesRepository
@@ -45,7 +42,6 @@ services:
     public: true
     arguments:
       - '@psxmarketingwithgoogle.db'
-      - '@psxmarketingwithgoogle.context'
 
   PrestaShop\Module\PsxMarketingWithGoogle\Repository\TaxRepository:
     class: PrestaShop\Module\PsxMarketingWithGoogle\Repository\TaxRepository

--- a/controllers/admin/AdminPsxMktgWithGoogleModuleController.php
+++ b/controllers/admin/AdminPsxMktgWithGoogleModuleController.php
@@ -182,5 +182,6 @@ class AdminPsxMktgWithGoogleModuleController extends ModuleAdminController
 
     public function postProcess()
     {
+        return false;
     }
 }

--- a/psxmarketingwithgoogle.php
+++ b/psxmarketingwithgoogle.php
@@ -167,7 +167,6 @@ class PsxMarketingWithGoogle extends Module
         // $uninstaller = $this->getService(Uninstaller::class);
 
         $uninstaller = new Uninstaller(
-            $this,
             $this->getService(TabRepository::class),
             $this->getService(Segment::class),
             $this->getService(ErrorHandler::class)


### PR DESCRIPTION
Since the first implementation of PHPStan in our development process, we did not increase the version because the docker image had changed. We were stuck on `PHPStan - PHP Static Analysis Tool 0.12.89`, a version released on 09/06/2021.

Keeping our tools up-to-date is important for the stability of our projects. However newer versions were using PHP 8 in their Docker image, preventing it to work with old version of PrestaShop.
This PR add PHPStan as a composer dependency so we can control the version used with the lock file, and we updated the CI workflow so PrestaShop versions are manually downloaded and unzipped.
