### PR TITLE
Open remarketing tag popin when after closing the config success popin

### DIFF
--- a/_dev/apps/ui/src/components/campaigns/campaign-card.vue
+++ b/_dev/apps/ui/src/components/campaigns/campaign-card.vue
@@ -76,28 +76,14 @@ export default {
       default: true,
     },
   },
-  computed: {
-    accountHasAtLeastOneCampaign() {
-      return !!this.$store.getters['campaigns/GET_ALL_CAMPAIGNS']?.length;
-    },
-    remarketingTagIsSet() {
-      return this.$store.getters['campaigns/GET_REMARKETING_TRACKING_TAG_IS_SET'];
-    },
-  },
   methods: {
     openPopinActivateTracking() {
       this.$segment.track('[GGL] Create SSC Config tab', {
         module: 'psxmarketingwithgoogle',
         params: SegmentGenericParams,
       });
-      // Prevent popin for opening if tracking is a campaign exists
-      if (this.accountHasAtLeastOneCampaign && this.remarketingTagIsSet) {
-        this.$router.push({
-          name: 'campaign-creation',
-        });
-      } else {
-        this.$emit('openPopin');
-      }
+
+      this.$emit('openPopin');
     },
   },
 };

--- a/_dev/apps/ui/src/components/commons/popin-configured.vue
+++ b/_dev/apps/ui/src/components/commons/popin-configured.vue
@@ -72,11 +72,6 @@ export default {
       ],
     };
   },
-  computed: {
-    accountHasAtLeastOneCampaign() {
-      return !!this.$store.getters['campaigns/GET_ALL_CAMPAIGNS']?.length;
-    },
-  },
   methods: {
     cancel() {
       this.$refs.modal.hide();
@@ -86,15 +81,9 @@ export default {
         module: 'psxmarketingwithgoogle',
         params: SegmentGenericParams,
       });
-      // Prevent popin for opening if tracking is a campaign exists
-      if (this.accountHasAtLeastOneCampaign) {
-        this.$router.push({
-          name: 'campaign-creation',
-        });
-      } else {
-        this.$refs.modal.hide();
-        this.$emit('openPopinRemarketingTag');
-      }
+
+      this.$refs.modal.hide();
+      this.$emit('openPopinRemarketingTag');
     },
   },
 };

--- a/_dev/apps/ui/src/views/onboarding-page.vue
+++ b/_dev/apps/ui/src/views/onboarding-page.vue
@@ -98,11 +98,11 @@
           v-if="stepsAreCompleted.step2"
           :is-enabled="stepsAreCompleted.step3"
           :loading="SSCIsLoading"
-          @openPopin="onOpenPopinActivateTracking"
+          @openPopin="proceedToCampaignCreation"
           @remarketingTagHasBeenActivated="checkAndOpenPopinConfigrationDone"
         />
         <CampaignTracking
-          v-if="getRemarketingTag !== null && accountHasAtLeastOneCampaign"
+          v-if="remarketingTagIsSet !== null && accountHasAtLeastOneCampaign"
         />
         <PromoCard />
       </div>
@@ -132,7 +132,7 @@
     />
     <PopinModuleConfigured
       ref="PopinModuleConfigured"
-      @openPopinRemarketingTag="onOpenPopinActivateTracking"
+      @openPopinRemarketingTag="proceedToCampaignCreation"
     />
     <!-- Toasts -->
     <PsToast
@@ -254,10 +254,17 @@ export default {
         this.$refs.GoogleAdsAccountPopinNew.$refs.modal.id,
       );
     },
-    onOpenPopinActivateTracking() {
-      this.$bvModal.show(
-        this.$refs.SSCPopinActivateTrackingOnboardingPage.$refs.modal.id,
-      );
+    proceedToCampaignCreation() {
+      // If the remarketing tag is not set yet, open the modal
+      if (!this.accountHasAtLeastOneCampaign || !this.remarketingTagIsSet) {
+        this.$bvModal.show(
+          this.$refs.SSCPopinActivateTrackingOnboardingPage.$refs.modal.id,
+        );
+        return;
+      }
+      this.$router.push({
+        name: 'campaign-creation',
+      });
     },
     toastIsClosed() {
       if (this.googleAccountConnectedOnce) {
@@ -379,7 +386,7 @@ export default {
     accountHasAtLeastOneCampaign() {
       return !!this.$store.getters['campaigns/GET_ALL_CAMPAIGNS']?.length;
     },
-    getRemarketingTag() {
+    remarketingTagIsSet() {
       return this.$store.getters['campaigns/GET_REMARKETING_TRACKING_TAG_IS_SET'];
     },
     stepsAreCompleted() {


### PR DESCRIPTION
The conditions to open the remarketing tag popin must be the same between the "Configuration successful popin" and the Google Ads account card.