### PR TITLE
Ignore response of claim call when overwrite is needed during reverification

### DIFF
--- a/_dev/apps/verification-tag/src/verification-tag-retriever.ts
+++ b/_dev/apps/verification-tag/src/verification-tag-retriever.ts
@@ -60,6 +60,13 @@ const responseHandler = async (response: Response) => {
     try {
       const content = await response.text();
       scope.setExtra('responseContent', content);
+
+      // Allow call to fails when the overwrite is requested by Google.
+      if (response.url.includes('shopping-websites/site-verification/claim')
+        && content.includes('"needOverwrite":true')
+      ) {
+        return response;
+      }
     } catch {
       // Do nothing
     }


### PR DESCRIPTION
HTTP 400 is tolerated on `claim` if Google requests overwrite to be set as true.
The proper message will be displayed on the configuration page.