### PR TITLE
Init API clients on App creation, not mount

### DIFF
--- a/_dev/apps/ui/src/App.vue
+++ b/_dev/apps/ui/src/App.vue
@@ -128,10 +128,7 @@ export default {
       return this.$store.state.app.backOfficeUserIsLoggedIn;
     },
   },
-  mounted() {
-    this.$root.identifySegment();
-    this.$store.dispatch('app/CHECK_FOR_AD_BLOCKER');
-    this.setCustomProperties();
+  created() {
     initShopClient({
       shopUrl: this.$store.state.app.psxMktgWithGoogleAdminAjaxUrl,
       onShopSessionLoggedOut: () => {
@@ -142,6 +139,12 @@ export default {
       apiUrl: this.$store.state.app.psxMktgWithGoogleApiUrl,
       token: this.$store.state.accounts.tokenPsAccounts,
     });
+  },
+  mounted() {
+    this.$root.identifySegment();
+    this.$store.dispatch('app/CHECK_FOR_AD_BLOCKER');
+    this.setCustomProperties();
+
     window.addEventListener('resize', this.resizeEventHandler);
   },
   destroyed() {


### PR DESCRIPTION
Since we load PS Accounts components from an external resource, it seems the mounted() event is triggered later, even too late compared to subcomponents already triggering API calls.

This PR moved the API initialization earlier in the process, so all API calls can succeed