### PR TITLE
Rebranding fixes part 2

### DIFF
--- a/_dev/apps/ui/src/assets/scss/base/_common.scss
+++ b/_dev/apps/ui/src/assets/scss/base/_common.scss
@@ -15,20 +15,6 @@ a[target="_blank"]:not(.external_link-no_icon) {
   }
 }
 
-.text-muted a[target="_blank"]:not(.external_link-no_icon),
-a[target="_blank"].text-muted:not(.external_link-no_icon) {
-  color: $grey_muted !important;
-}
-
-.text-muted a.with-hover,
-a.text-muted.with-hover {
-  color: $grey_muted !important;
-
-  &:hover, &:focus {
-    color: $blue !important;
-  }
-}
-
 a.without-hover {
   &:hover, &:focus {
     text-decoration: none;

--- a/_dev/apps/ui/src/assets/scss/components/_sync-history.scss
+++ b/_dev/apps/ui/src/assets/scss/components/_sync-history.scss
@@ -62,7 +62,6 @@
 
     &-description {
       font-size: rem(13);
-      color: $secondary;
     }
   }
 }

--- a/_dev/apps/ui/src/assets/scss/components/_table-carriers.scss
+++ b/_dev/apps/ui/src/assets/scss/components/_table-carriers.scss
@@ -12,7 +12,7 @@
 
   &__description {
     font-size: rem(10);
-    color: $secondary;
+    color: $text-muted;
     margin-bottom: 0;
   }
 

--- a/_dev/apps/ui/src/components/campaign-creation/campaign-creation.vue
+++ b/_dev/apps/ui/src/components/campaign-creation/campaign-creation.vue
@@ -55,7 +55,7 @@
             >
               <b-link
                 :to="{ name: 'help' }"
-                class="with-hover text-decoration-underline"
+                class="text-decoration-underline"
               >
                 {{ $t("general.helpPage") }}
               </b-link>

--- a/_dev/apps/ui/src/components/merchant-center-account/merchant-center-account-card.spec.ts
+++ b/_dev/apps/ui/src/components/merchant-center-account/merchant-center-account-card.spec.ts
@@ -61,7 +61,7 @@ describe('merchant-center-account-card.vue', () => {
     // Check enabled state
     expect(wrapper.find('.ps_gs-onboardingcard').classes('ps_gs-onboardingcard--disabled')).toBe(false);
     // Check button to create an account exists
-    expect(wrapper.find('.with-hover').text()).toBe('create your account');
+    expect(wrapper.find('.text-decoration-underline').text()).toBe('create your account');
   });
 });
 

--- a/_dev/apps/ui/src/components/product-feed-page/submitted-products/products-status-card.vue
+++ b/_dev/apps/ui/src/components/product-feed-page/submitted-products/products-status-card.vue
@@ -13,7 +13,7 @@
         <h3 class="ps_gs-fz-13 font-weight-600 mb-1 line-height-15">
           {{ card.title }}
         </h3>
-        <p class="mb-0 ps_gs-fz-12 line-height-13 text-secondary">
+        <p class="mb-0 ps_gs-fz-12 line-height-13">
           {{ card.description }}
         </p>
       </div>

--- a/_dev/apps/ui/src/components/product-feed-page/submitted-products/submitted-products.vue
+++ b/_dev/apps/ui/src/components/product-feed-page/submitted-products/submitted-products.vue
@@ -55,7 +55,7 @@
         <h2 class="ps_gs-fz-16 font-weight-600">
           {{ $t('productFeedPage.overview.title') }}
         </h2>
-        <p class="text-secondary ps_gs-fz-13 mb-2">
+        <p class="ps_gs-fz-13 mb-2">
           {{ $t('productFeedPage.overview.description') }}
         </p>
       </div>


### PR DESCRIPTION
* [Remove seconday color on some texts, as the grey was now too bright](https://github.com/PrestaShopCorp/psxmarketingwithgoogle/pull/1450/commits/d0f29670146d5358e5b1a8eee82cf6ef4534945e)
* [Make more links displayed in blue even when muted](https://github.com/PrestaShopCorp/psxmarketingwithgoogle/pull/1450/commits/0972b11567624ed5193433da729978ab780ae4f4)