### PR TITLE
Display account suspension alert on new product feed page

### DIFF
--- a/_dev/apps/ui/src/components/merchant-center-account/merchant-center-account-alert-suspended.vue
+++ b/_dev/apps/ui/src/components/merchant-center-account/merchant-center-account-alert-suspended.vue
@@ -2,7 +2,7 @@
   <b-alert
     show
     variant="danger"
-    class="mb-0 mt-3"
+    class="mt-3"
   >
     <strong>{{ $t('mcaCard.alertSuspended') }}</strong><br>
     <VueShowdown
@@ -37,8 +37,8 @@
 
 <script lang="ts">
 import {content_v2_1 as contentApi} from '@googleapis/content/v2.1';
-import googleUrl from '@/assets/json/googleUrl.json';
 import {PropType, defineComponent} from 'vue';
+import googleUrl from '@/assets/json/googleUrl.json';
 
 export default defineComponent({
   name: 'MerchantCenterAccountAlertSuspended',

--- a/_dev/apps/ui/src/components/merchant-center-account/merchant-center-account-alert-suspended.vue
+++ b/_dev/apps/ui/src/components/merchant-center-account/merchant-center-account-alert-suspended.vue
@@ -1,0 +1,57 @@
+<template>
+  <b-alert
+    show
+    variant="danger"
+    class="mb-0 mt-3"
+  >
+    <strong>{{ $t('mcaCard.alertSuspended') }}</strong><br>
+    <VueShowdown
+      :markdown="$t('mcaCard.alertSuspendedDescription', [
+        accountOverviewUrl,
+        $options.googleUrl.requestiongReReview
+      ])"
+      :extensions="['extended-link']"
+    />
+    <span class="text-muted d-block">
+      <template
+        v-for="(issue, index) in issues"
+      ><!--
+      comment is necessary to have the comma next to the link
+    --><span
+    v-if="index !== 0"
+    class="mr-2"
+    :key="'span-' + index"
+        >, </span><!--
+      comment is necessary to have the comma next to the link
+    --><a
+      :key="index"
+      :href="issue.documentation"
+      target="_blank"
+      class="text-muted ps_gs-fz-12 font-weight-normal mt-3 mt-md-0"
+      v-html="$t('mcaCard.linkLearnMoreAbout', [issue.title])"
+    />
+      </template>
+    </span>
+  </b-alert>
+</template>
+
+<script lang="ts">
+import {content_v2_1 as contentApi} from '@googleapis/content/v2.1';
+import googleUrl from '@/assets/json/googleUrl.json';
+import {PropType, defineComponent} from 'vue';
+
+export default defineComponent({
+  name: 'MerchantCenterAccountAlertSuspended',
+  props: {
+    issues: {
+      type: Object as PropType<contentApi.Schema$AccountStatusAccountLevelIssue[]>,
+      required: true,
+    },
+    accountOverviewUrl: {
+      type: String,
+      required: true,
+    },
+  },
+  googleUrl,
+});
+</script>

--- a/_dev/apps/ui/src/components/merchant-center-account/merchant-center-account-card.vue
+++ b/_dev/apps/ui/src/components/merchant-center-account/merchant-center-account-card.vue
@@ -36,7 +36,7 @@
           </b-badge>
           <div
             class="flex-grow-1 d-flex-md flex-md-grow-1 flex-shrink-0 text-right"
-            v-if="selectedMcaDetails.id === null"
+            v-if="gmcAccountDetails.id === null"
           >
             <b-button
               size="sm"
@@ -88,7 +88,7 @@
           </div>
         </div>
         <div
-          v-if="isEnabled && selectedMcaDetails.id === null"
+          v-if="isEnabled && gmcAccountDetails.id === null"
           class="ml-2 ps_gs-onboardingcard__content"
         >
           <VueShowdown
@@ -97,7 +97,7 @@
             tag="p"
             :markdown="this.$i18n.t('mcaCard.introDisabled')"
             :extensions="['no-p-tag', 'extended-b-link']"
-            v-if="selectedMcaDetails.id === null"
+            v-if="gmcAccountDetails.id === null"
             :vue-template="true"
           />
           <b-form class="mb-2 mt-3">
@@ -286,7 +286,7 @@
                 target="_blank"
                 class="external_link-no_icon link-regular"
               >
-                {{ selectedMcaDetails.name }} - {{ selectedMcaDetails.id }}
+                {{ gmcAccountDetails.name }} - {{ gmcAccountDetails.id }}
               </a>
               <span
                 v-if="loaderText"
@@ -306,10 +306,11 @@
             </div>
           </div>
         </div>
-        <merchant-center-account-alert-suspended 
+        <merchant-center-account-alert-suspended
           v-if="error === WebsiteClaimErrorReason.Suspended"
-          :issues="selectedMcaDetails.isSuspended.issues"
+          :issues="gmcAccountDetails.isSuspended.issues"
           :account-overview-url="merchantCenterWebsitePageUrl.overview"
+          class="mb-0"
         />
         <b-alert
           v-else-if="error === WebsiteClaimErrorReason.OverwriteNeeded"
@@ -505,6 +506,7 @@ import googleUrl from '@/assets/json/googleUrl.json';
 import {
   WebsiteClaimErrorReason,
 } from '../../store/modules/accounts/state';
+import {getMerchantCenterWebsiteUrls} from './merchant-center-account-links';
 import MerchantCenterAccountAlertSuspended from '@/components/merchant-center-account/merchant-center-account-alert-suspended.vue';
 import MerchantCenterAccountPopinOverwriteClaim from './merchant-center-account-popin-overwrite-claim';
 import MerchantCenterAccountPopinWebsiteRequirements from './merchant-center-account-popin-website-requirements.vue';
@@ -588,7 +590,7 @@ export default {
     mcaConfigured() {
       return this.$store.getters['accounts/GET_GOOGLE_MERCHANT_CENTER_ACCOUNT_IS_CONFIGURED'];
     },
-    selectedMcaDetails() {
+    gmcAccountDetails() {
       return this.$store.getters['accounts/GET_GOOGLE_MERCHANT_CENTER_ACCOUNT'];
     },
     mcaIsNotConnected() {
@@ -649,13 +651,7 @@ export default {
       }
     },
     merchantCenterWebsitePageUrl() {
-      const {id} = this.$store.state.accounts.googleMerchantAccount;
-
-      return {
-        website: `https://merchants.google.com/mc/settings/website?a=${id}`,
-        businessInfo: `https://merchants.google.com/mc/merchantprofile/businessinfo?a=${id}`,
-        overview: `https://merchants.google.com/mc/overview?a=${id}`,
-      };
+      return getMerchantCenterWebsiteUrls(this.gmcAccountDetails.id);
     },
     websiteUrl() {
       return this.$store.state.accounts.googleMerchantAccount.websiteUrl;
@@ -675,16 +671,16 @@ export default {
     },
     isLinkedGmcStillCreating() {
       return this.isEnabled
-        && this.selectedMcaDetails.id !== null
+        && this.gmcAccountDetails.id !== null
         && !this.mcaListLoading
-        && (this.selectedMcaDetails.name === null || this.selectedMcaDetails.name === undefined);
+        && (this.gmcAccountDetails.name === null || this.gmcAccountDetails.name === undefined);
     },
     isLinkedGmcFullyFetched() {
       return this.isEnabled
-        && this.selectedMcaDetails.id !== null
+        && this.gmcAccountDetails.id !== null
         && !this.mcaListLoading
-        && this.selectedMcaDetails.name !== null
-        && this.selectedMcaDetails.name !== undefined;
+        && this.gmcAccountDetails.name !== null
+        && this.gmcAccountDetails.name !== undefined;
     },
     hasGmcCreatedFromModule() {
       const isFromModule = this.mcaSelectionOptions?.findIndex((option) => 'aggregatorId' in option && option.aggregatorId === this.$store.state.accounts.mcaPrestashopId);

--- a/_dev/apps/ui/src/components/merchant-center-account/merchant-center-account-card.vue
+++ b/_dev/apps/ui/src/components/merchant-center-account/merchant-center-account-card.vue
@@ -306,41 +306,11 @@
             </div>
           </div>
         </div>
-        <b-alert
+        <merchant-center-account-alert-suspended 
           v-if="error === WebsiteClaimErrorReason.Suspended"
-          show
-          variant="danger"
-          class="mb-0 mt-3"
-        >
-          <strong>{{ $t('mcaCard.alertSuspended') }}</strong><br>
-          <VueShowdown
-            :markdown="$t('mcaCard.alertSuspendedDescription', [
-              merchantCenterWebsitePageUrl.overview,
-              $options.googleUrl.requestiongReReview
-            ])"
-            :extensions="['extended-link']"
-          />
-          <span class="text-muted d-block">
-            <template
-              v-for="(issue, index) in selectedMcaDetails.isSuspended.issues"
-            ><!--
-            comment is necessary to have the comma next to the link
-          --><span
-          v-if="index !== 0"
-          class="mr-2"
-          :key="'span-' + index"
-              >, </span><!--
-            comment is necessary to have the comma next to the link
-          --><a
-            :key="index"
-            :href="issue.documentation"
-            target="_blank"
-            class="text-muted ps_gs-fz-12 font-weight-normal mt-3 mt-md-0"
-            v-html="$t('mcaCard.linkLearnMoreAbout', [issue.title])"
-          />
-            </template>
-          </span>
-        </b-alert>
+          :issues="selectedMcaDetails.isSuspended.issues"
+          :account-overview-url="merchantCenterWebsitePageUrl.overview"
+        />
         <b-alert
           v-else-if="error === WebsiteClaimErrorReason.OverwriteNeeded"
           show
@@ -535,6 +505,7 @@ import googleUrl from '@/assets/json/googleUrl.json';
 import {
   WebsiteClaimErrorReason,
 } from '../../store/modules/accounts/state';
+import MerchantCenterAccountAlertSuspended from '@/components/merchant-center-account/merchant-center-account-alert-suspended.vue';
 import MerchantCenterAccountPopinOverwriteClaim from './merchant-center-account-popin-overwrite-claim';
 import MerchantCenterAccountPopinWebsiteRequirements from './merchant-center-account-popin-website-requirements.vue';
 import PhoneVerificationPopin from './phone-verification/phone-verification-popin.vue';
@@ -544,6 +515,7 @@ import AlertModuleDisabled from '@/components/commons/alert-module-disabled';
 export default {
   name: 'MerchantCenterAccountCard',
   components: {
+    MerchantCenterAccountAlertSuspended,
     MerchantCenterAccountPopinOverwriteClaim,
     MerchantCenterAccountPopinWebsiteRequirements,
     VueShowdown,

--- a/_dev/apps/ui/src/components/merchant-center-account/merchant-center-account-links.ts
+++ b/_dev/apps/ui/src/components/merchant-center-account/merchant-center-account-links.ts
@@ -1,0 +1,9 @@
+const getMerchantCenterWebsiteUrls = (id: string) => ({
+  website: `https://merchants.google.com/mc/settings/website?a=${id}`,
+  businessInfo: `https://merchants.google.com/mc/merchantprofile/businessinfo?a=${id}`,
+  overview: `https://merchants.google.com/mc/overview?a=${id}`,
+});
+
+export default {
+  getMerchantCenterWebsiteUrls,
+};

--- a/_dev/apps/ui/src/components/product-feed-page/sync-overview.vue
+++ b/_dev/apps/ui/src/components/product-feed-page/sync-overview.vue
@@ -31,6 +31,11 @@
           border-top border-md-top-0 border-md-left border-600-20
         "
       >
+        <merchant-center-account-alert-suspended
+          v-if="gmcAccountIsSuspended"
+          :issues="gmcAccountDetails.isSuspended.issues"
+          :account-overview-url="gmcAccountOverviewPage"
+        />
         <feed-configuration-card
           v-if="loading || incrementalSyncContext"
           :product-feed-configuration="incrementalSyncContext"
@@ -61,6 +66,8 @@ import ProductsStatusCard from './submitted-products/products-status-card';
 import SyncHistory from './sync-history/sync-history';
 import SyncState from './sync-history/sync-state';
 import {IncrementalSyncContext} from './feed-configuration/feed-configuration';
+import {WebsiteClaimErrorReason} from '@/store/modules/accounts/state';
+import {getMerchantCenterWebsiteUrls} from '@/components/merchant-center-account/merchant-center-account-links';
 
 export default defineComponent({
   components: {
@@ -84,6 +91,16 @@ export default defineComponent({
   computed: {
     incrementalSyncContext(): IncrementalSyncContext|undefined {
       return this.$store.getters['productFeed/GET_PRODUCT_FEED_SYNC_CONTEXT'];
+    },
+    gmcAccountDetails() {
+      return this.$store.getters['accounts/GET_GOOGLE_MERCHANT_CENTER_ACCOUNT'];
+    },
+    gmcAccountIsSuspended() {
+      return this.$store.getters['accounts/GET_GOOGLE_ACCOUNT_WEBSITE_CLAIMING_OVERRIDE_STATUS']
+      === WebsiteClaimErrorReason.Suspended;
+    },
+    gmcAccountOverviewPage() {
+      return getMerchantCenterWebsiteUrls(this.gmcAccountDetails.id).overview;
     },
   },
 });

--- a/_dev/apps/ui/src/components/product-feed-page/sync-overview.vue
+++ b/_dev/apps/ui/src/components/product-feed-page/sync-overview.vue
@@ -55,6 +55,7 @@
 import {defineComponent} from 'vue';
 import NotConfiguredCard from '@/components/commons/not-configured-card';
 import FeedConfigurationCard from './feed-configuration/feed-configuration-card.vue';
+import MerchantCenterAccountAlertSuspended from '@/components/merchant-center-account/merchant-center-account-alert-suspended.vue';
 import SubmittedProducts from './submitted-products/submitted-products';
 import ProductsStatusCard from './submitted-products/products-status-card';
 import SyncHistory from './sync-history/sync-history';
@@ -64,9 +65,10 @@ import {IncrementalSyncContext} from './feed-configuration/feed-configuration';
 export default defineComponent({
   components: {
     FeedConfigurationCard,
+    MerchantCenterAccountAlertSuspended,
     NotConfiguredCard,
-    SubmittedProducts,
     ProductsStatusCard,
+    SubmittedProducts,
     SyncHistory,
     SyncState,
   },

--- a/_dev/apps/ui/src/store/modules/accounts/state.ts
+++ b/_dev/apps/ui/src/store/modules/accounts/state.ts
@@ -85,7 +85,7 @@ export type GoogleAccountContext = GoogleAccount
 
 export type ShoppingWebsiteStatusFlag = {
   status: boolean;
-  issues?: Array<contentApi.Schema$AccountStatusAccountLevelIssue>;
+  issues?: contentApi.Schema$AccountStatusAccountLevelIssue[];
 }
 
 export type MerchantCenterAccountContext = GoogleMerchantAccount & {

--- a/_dev/apps/ui/stories/product-feed-page.stories.ts
+++ b/_dev/apps/ui/stories/product-feed-page.stories.ts
@@ -18,6 +18,7 @@ import {
 } from '../.storybook/mock/campaigns-list';
 
 import { rest } from 'msw';
+import merchantCenterAccountConnected from '../.storybook/mock/merchant-center-account';
 
 export default {
   title: 'Product-Feed-Page/Product Feed Page',
@@ -357,6 +358,96 @@ SyncFailed.parameters = {
         return res(
           ctx.json({
             ...productFeed.prevalidationScanSummary
+          })
+        );
+      }),
+      rest.get('/shopping-campaigns/list', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            ...campaignsListResponse,
+          })
+        );
+      }),
+    ],
+  },
+};
+
+export const AccountSuspended:any = ProductFeed.bind({});
+AccountSuspended.args = {
+  beforeMount() {
+    this.$store.state.accounts.googleMerchantAccount = cloneDeep(Object.assign({},
+      merchantCenterAccountConnected,
+      {
+        isSuspended: {
+          status: true,
+          issues: [
+            {
+              id: 'editorial_and_professional_standards_destination_url_down_policy',
+              title:
+                'Account suspended due to policy violation: landing page not working',
+              country: 'US',
+              severity: 'critical',
+              documentation:
+                'https://google.com/first-link',
+            },
+            {
+              id: 'editorial_and_professional_standards_destination_url_down_policy',
+              title:
+                'Account suspended due to policy violation: Oh no',
+              country: 'US',
+              severity: 'critical',
+              documentation:
+                'https://google.com/second-link',
+            },
+          ]
+        },
+      },
+    ));
+    this.$store.state.productFeed.report = cloneDeep(productFeedIsConfigured.report);
+  },
+}
+AccountSuspended.parameters = {
+  msw: {
+    handlers: [
+      rest.get('/incremental-sync/status/*', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            ...productFeedStatusSyncSuccess.status,
+          })
+        );
+      }),
+      rest.get('/incremental-sync/settings/*', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            ...productFeedStatusSyncSuccess.settings,
+          })
+        );
+      }),
+      rest.get('/product-feeds/validation/summary', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            ...productFeedStatusSyncSuccess.validationSummary
+          })
+        );
+      }),
+      rest.get('/product-feeds/prevalidation-scan/summary', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            ...productFeed.prevalidationScanSummary
+          })
+        );
+      }),
+      rest.get('/ads-accounts/list', (req, res, ctx) => {
+        return res(
+          ctx.json(
+            googleAdsNotChosen.list
+          )
+        );
+      }),
+      rest.get('/ads-accounts/status', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            ...adsAccountStatus,
           })
         );
       }),


### PR DESCRIPTION
![image](https://github.com/PrestaShopCorp/psxmarketingwithgoogle/assets/6768917/12de32ee-f09b-4d43-a9c1-a529697b5065)

- [x] Requires https://github.com/PrestaShopCorp/psxmarketingwithgoogle/pull/1455 to be merged to focus the history on the alert changes