### PR TITLE
chore: upgrade github actions node16

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/.github/workflows/cdn-preproduction.yml
+++ b/.github/workflows/cdn-preproduction.yml
@@ -35,7 +35,7 @@ jobs:
           PATCH: ${{ steps.get_tag.outputs.PATCH }}
 
       - name: Trigger storage preproduction
-        uses: aurelien-baudet/workflow-dispatch@v2
+        uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: ${{ env.WORKFLOW }}
           repo: PrestaShopCorp/services-deployment

--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -39,7 +39,7 @@ jobs:
 
 
       - name: Trigger storage production
-        uses: aurelien-baudet/workflow-dispatch@v2
+        uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: ${{ env.WORKFLOW }}
           repo: PrestaShopCorp/services-deployment

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -25,13 +25,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache
           key: php-composer-cache
@@ -63,16 +63,16 @@ jobs:
           php-version: 7.4
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache vendor folder
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor
           key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Cache composer folder
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache
           key: php-composer-cache
@@ -100,13 +100,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache
           key: php-composer-cache
@@ -129,13 +129,13 @@ jobs:
           php-version: '7.4'
 
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache
           key: php-composer-cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,10 +82,9 @@ jobs:
           zip -r ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.zip ${{ github.event.repository.name }} -x '*.git*'
 
       - name: Publish the production zip
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: shogo82148/actions-upload-release-asset@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./${{ github.event.repository.name }}/${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.zip
           asset_name: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.zip
@@ -121,10 +120,9 @@ jobs:
           zip -r ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}_preproduction.zip ${{ github.event.repository.name }} -x '*.git*'
 
       - name: Publish the preproduction zip
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: shogo82148/actions-upload-release-asset@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./${{ github.event.repository.name }}/${{ github.event.repository.name }}-${{ github.event.release.tag_name }}_preproduction.zip
           asset_name: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}_preproduction.zip
@@ -160,10 +158,9 @@ jobs:
           zip -r ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}_integration.zip ${{ github.event.repository.name }}  -x '*.git*'
 
       - name: Publish the integration zip
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: shogo82148/actions-upload-release-asset@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./${{ github.event.repository.name }}/${{ github.event.repository.name }}-${{ github.event.release.tag_name }}_integration.zip
           asset_name: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}_integration.zip

--- a/.github/workflows/storybook-ci-cd.yml
+++ b/.github/workflows/storybook-ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
         uses: tj-actions/branch-names@v5.1
 
       - name: Trigger build and deploy
-        uses: aurelien-baudet/workflow-dispatch@v2
+        uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: googleshopping-storybook.yml
           repo: PrestaShopCorp/services-deployment
@@ -43,7 +43,7 @@ jobs:
         uses: tj-actions/branch-names@v5.1
 
       - name: Trigger build and deploy
-        uses: aurelien-baudet/workflow-dispatch@v2
+        uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: googleshopping-storybook.yml
           repo: PrestaShopCorp/services-deployment


### PR DESCRIPTION
Upgrade Github actions with versions compatible with node16 https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/

Actions replaced because there're archived or not updated anymore :
aurelien-baudet/workflow-dispatch@v2 -> [benc-uk/workflow-dispatch@v1](https://github.com/benc-uk/workflow-dispatch/tree/v1/)
actions/upload-release-asset@v1.0.1 -> [shogo82148/actions-upload-release-asset@v1](https://github.com/shogo82148/actions-upload-release-asset/tree/v1/)