### PR TITLE
Display currencies in product feed's configuration

### DIFF
--- a/_dev/apps/ui/.storybook/mock/product-feed.ts
+++ b/_dev/apps/ui/.storybook/mock/product-feed.ts
@@ -512,7 +512,7 @@ export const productFeedIsConfigured: State = {
   report: {
     lastConfigurationUsed: {
       lastModificationDate: new Date(2023, 6, 31, 13, 37),
-      targetCountries: ['FR', 'UK', 'IT'],
+      targetCountries: ['FR', 'GB', 'IT'], 
       languages: ['it', 'fr', 'de'],
     },
     productsInCatalog: null,
@@ -665,7 +665,7 @@ export const productFeedStatusSyncSuccess: State = {
   report: {
     lastConfigurationUsed: {
       lastModificationDate: new Date(2023, 6, 31, 13, 37),
-      targetCountries: ['FR', 'UK', 'IT'],
+      targetCountries: ['FR', 'GB', 'IT'],
       languages: ['it', 'fr', 'de'],
     },
     productsInCatalog: "1362452",

--- a/_dev/apps/ui/src/components/product-feed-page/dashboard/feed-configuration/feed-configuration-card.spec.ts
+++ b/_dev/apps/ui/src/components/product-feed-page/dashboard/feed-configuration/feed-configuration-card.spec.ts
@@ -30,8 +30,8 @@ describe('feed-configuration-card.vue', () => {
     expect(lastConfigurationDateFound.text()).toEqual('25/12/2022, 23:55');
 
     expect(countriesFound).toHaveLength(2);
-    expect(countriesFound.at(0).text()).toEqual('France');
-    expect(countriesFound.at(1).text()).toEqual('Italy');
+    expect(countriesFound.at(0).text()).toEqual('France (EUR)');
+    expect(countriesFound.at(1).text()).toEqual('Italy (EUR)');
 
     expect(languagesFound).toHaveLength(3);
     expect(languagesFound.at(0).text()).toEqual('it');
@@ -48,6 +48,7 @@ describe('feed-configuration-card.vue', () => {
         productFeedConfiguration: null,
         loading: true,
       },
+      store: new Vuex.Store(cloneStore()),
     });
 
     const countriesFound = wrapper.findAll('[data-test-id="pf-config-country"]');
@@ -76,13 +77,14 @@ describe('feed-configuration-card.vue', () => {
         },
         loading: false,
       },
+      store: new Vuex.Store(cloneStore()),
     });
     const countriesFound = wrapper.findAll('[data-test-id="pf-config-country"]');
     const noElligibleLang = wrapper.find('[data-test-id="pf-config-no-lang"]');
     const languagesAlert = wrapper.find('.alert-danger');
 
     expect(countriesFound).toHaveLength(1);
-    expect(countriesFound.at(0).text()).toEqual('France');
+    expect(countriesFound.at(0).text()).toEqual('France (EUR)');
 
     expect(noElligibleLang.exists()).toBeTruthy();
     expect(noElligibleLang.text()).toEqual('No eligible language');


### PR DESCRIPTION
This PR implements an example of display for currencies inside the product feed's configuration.
It shows how we could display an additional case where a specific currency was not found on the shop.

![image](https://github.com/PrestaShopCorp/psxmarketingwithgoogle/assets/6768917/54c4c02b-8036-48d2-9657-ef3ee13594ed)
