### PR TITLE
Fix path of image in modal "onboarding success"

### DIFF
--- a/_dev/apps/ui/src/components/commons/popin-configured.vue
+++ b/_dev/apps/ui/src/components/commons/popin-configured.vue
@@ -18,9 +18,9 @@
           {{ $t("configuredState.title") }}
         </h2>
 
-        <b-img
+        <img
           src="@/assets/images/configured.svg"
-          fluid
+          class="img-fluid"
         />
         <VueShowdown
           class="mt-4"


### PR DESCRIPTION
![image](https://github.com/PrestaShopCorp/psxmarketingwithgoogle/assets/6768917/a7fd19c5-088c-4178-a76e-2a38b9457d17)
