### PR TITLE
Fix backward compatibility

### DIFF
--- a/_dev/apps/ui/src/bc-ante-vite.ts
+++ b/_dev/apps/ui/src/bc-ante-vite.ts
@@ -1,5 +1,5 @@
 const scriptElement = document.createElement('script');
 scriptElement.type = 'text/javascript';
-scriptElement.src = import.meta.url.replace('app.js', 'psxmarketingwithgoogle-ui.js');
+scriptElement.src = (document.currentScript as HTMLScriptElement).src.replace('app.js', 'psxmarketingwithgoogle-ui.js');
 scriptElement.type = 'module';
 document.head.append(scriptElement);


### PR DESCRIPTION
The use of `import.meta.url` is unavailable in scripts not imported as module.

This is precisely how the merchants are loading the file app.js in previous versions.
We had to find another solution for them in order to load dynamically the new script.