### PR TITLE
Fix responsiveness of graph

### DIFF
--- a/_dev/apps/ui/src/components/campaign/reporting/key-metrics/key-metrics-chart-wrapper.vue
+++ b/_dev/apps/ui/src/components/campaign/reporting/key-metrics/key-metrics-chart-wrapper.vue
@@ -138,6 +138,7 @@ export default {
             max: this.$store.getters['campaigns/GET_REPORTING_END_DATES'],
           },
         },
+        maintainAspectRatio: false,
         plugins: {
           legend: {
             display: false,


### PR DESCRIPTION
On betas 1 & 2, reducing then increasing the width of the page has a bad result on the reporting graph, as it was not reacting to the width increase and stayed small on the page.