### PR TITLE
Follow acceptance criteria for the first campaign creation CTA

### DIFF
--- a/_dev/packages/mktg-with-google-common/translations/en/ui.json
+++ b/_dev/packages/mktg-with-google-common/translations/en/ui.json
@@ -1109,7 +1109,7 @@
       "legendLong": "*Your voucher will be applied automatically from the moment you start spending! *The amount needs to be spent within 60 days of the first campaign spend and credits will be valid for 60 days once credited. [Read T&C]({0})[:target=\"_blank\"]",
       "legend": "*Create a new Google Ads account, the voucher will be applied automatically once you match the spend and you will have 60 days to spend the credits. [Read T&C]({0})[:target=\"_blank\"]",
       "legendWithoutTC": "* Create a new Google Ads account, the voucher will be applied automatically once you match the spend and you will have 60 days to spend the credits.",
-      "ctaCreateFirstCampaign": "Launch your first campaign",
+      "ctaCreateFirstCampaign": "Create your first PMax campaign",
       "textCampaignsBanner":  "Create your first campaign and reach more relevant shoppers across all Google’s channels. Let Google’s machine learning optimize your ad placements and efficiently improve your traffic and sales."
     },
     "tipsAndTricks": {


### PR DESCRIPTION
> **CA 15 :**
**Given that :** a merchant that hasn't created his first campaign and he visits the campaign page
**When :** he click on the CTA 'Create your first PMax campaign' displayed in a banner at the top of the page
**Then :** he is redirected on the campaign creation form