### PR TITLE
Update font sizes of product feed pages

### DIFF
--- a/_dev/apps/ui/src/assets/scss/components/_badge.scss
+++ b/_dev/apps/ui/src/assets/scss/components/_badge.scss
@@ -27,7 +27,6 @@
 
   &__badge {
     border-radius: 0;
-    font-weight: 600;
     white-space: nowrap;
 
     .card-body {

--- a/_dev/apps/ui/src/components/product-feed-page/dashboard/feed-configuration/feed-configuration-card.vue
+++ b/_dev/apps/ui/src/components/product-feed-page/dashboard/feed-configuration/feed-configuration-card.vue
@@ -115,7 +115,7 @@
                 v-for="(country, index) in targetCountriesDetails"
                 :border-variant="country.currencyIsFound ? 'primary' : 'danger'"
                 :text-variant="country.currencyIsFound ? 'primary' : 'danger'"
-                class="mx-1 d-inline-flex ps_gs-productfeed__badge ps_gs-fz-13 mb-2"
+                class="mx-1 d-inline-flex ps_gs-productfeed__badge ps_gs-fz-13 font-weight-600 mb-2"
                 :key="index"
                 data-test-id="pf-config-country"
               >
@@ -155,7 +155,7 @@
                 <b-card
                   v-for="(language, index) in languages"
                   border-variant="primary"
-                  class="mx-1 d-inline-flex ps_gs-productfeed__badge ps_gs-fz-13 mb-2"
+                  class="mx-1 d-inline-flex ps_gs-productfeed__badge ps_gs-fz-13 font-weight-600 mb-2"
                   :key="index"
                   data-test-id="pf-config-lang"
                 >

--- a/_dev/apps/ui/src/components/product-feed-page/dashboard/status-card.vue
+++ b/_dev/apps/ui/src/components/product-feed-page/dashboard/status-card.vue
@@ -69,7 +69,7 @@
             :border-variant="badgeBorderVariant"
             :text-variant="badgeTextVariant"
             :bg-variant="badgeBackgroundVariant"
-            class="ps_gs-productfeed__badge mt-auto"
+            class="ps_gs-productfeed__badge mt-auto ps_gs-fz-16 font-weight-500"
             body-class="px-3"
           >
             {{ badgeValue }}

--- a/_dev/apps/ui/src/components/product-feed-page/non-compliant-products-details-page/non-compliant-products-details-row.vue
+++ b/_dev/apps/ui/src/components/product-feed-page/non-compliant-products-details-page/non-compliant-products-details-row.vue
@@ -30,7 +30,7 @@
         v-for="langIso in verificationIssueProduct.langs"
         :key="langIso"
         border-variant="primary"
-        class="mx-1 d-inline-flex ps_gs-productfeed__badge ps_gs-fz-13"
+        class="mx-1 d-inline-flex ps_gs-productfeed__badge ps_gs-fz-13 font-weight-500"
       >
         {{ langIso }}
       </b-card>

--- a/_dev/apps/ui/src/components/product-feed-page/non-compliant-products-page/non-compliant-products-row.vue
+++ b/_dev/apps/ui/src/components/product-feed-page/non-compliant-products-page/non-compliant-products-row.vue
@@ -36,7 +36,7 @@
         v-for="(numberOfProducts, langIso) in verificationIssue.affected"
         :key="langIso"
         border-variant="primary"
-        class="mx-1 d-inline-flex ps_gs-productfeed__badge ps_gs-fz-13"
+        class="mx-1 d-inline-flex ps_gs-productfeed__badge ps_gs-fz-13 font-weight-500"
       >
         {{ langIso }}
       </b-card>


### PR DESCRIPTION
![image](https://github.com/PrestaShopCorp/psxmarketingwithgoogle/assets/6768917/3db330d3-1e11-4d0f-be8b-7800c3fcf11f)

* font-size: 13px
* font-weight: 600

Source: https://www.figma.com/file/BhjRbRHDyte9F0HKTP2yUW/Product-Feed?type=design&node-id=617-10681&mode=design&t=h9377QZgna3PytG8-4

--------

![image](https://github.com/PrestaShopCorp/psxmarketingwithgoogle/assets/6768917/57b8ffa5-3e21-4b71-b5a1-e21c21873dde)

* font-size: 16px
* font-weight: 500

Source: https://www.figma.com/file/BhjRbRHDyte9F0HKTP2yUW/Product-Feed?type=design&node-id=20-7007&mode=design&t=h9377QZgna3PytG8-4

--------

![image](https://github.com/PrestaShopCorp/psxmarketingwithgoogle/assets/6768917/477c6115-b05c-4eb7-9a50-0a5ccbd0345c)
![image](https://github.com/PrestaShopCorp/psxmarketingwithgoogle/assets/6768917/83862fd8-6ad8-4680-bd98-a74855f635ce)


* font-size: 13px
* font-weight: 500

Source: https://www.figma.com/file/BhjRbRHDyte9F0HKTP2yUW/Product-Feed?type=design&node-id=19-11377&mode=design&t=h9377QZgna3PytG8-4