### PR TITLE
Fix CloudSync sync-api URL

### DIFF
--- a/_dev/apps/ui/src/store/modules/product-feed/actions.ts
+++ b/_dev/apps/ui/src/store/modules/product-feed/actions.ts
@@ -318,7 +318,7 @@ export default {
     return result;
   },
   async [ActionsTypes.REQUEST_SYNCHRONISATION]({rootState}: Context, full = false) {
-    const response = await fetch(`https://eventbus-sync.psessentials.net/sync/trigger${full ? '-full' : ''}`, {
+    const response = await fetch(`https://api.cloudsync.prestashop.com/sync/v1//trigger${full ? '-full' : ''}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/_dev/apps/ui/src/store/modules/product-feed/actions.ts
+++ b/_dev/apps/ui/src/store/modules/product-feed/actions.ts
@@ -318,8 +318,8 @@ export default {
     return result;
   },
   async [ActionsTypes.REQUEST_SYNCHRONISATION]({rootState}: Context, full = false) {
-    const response = await fetch(`https://api.cloudsync.prestashop.com/sync/v1//trigger${full ? '-full' : ''}`, {
-      method: 'GET',
+    const response = await fetch(`https://api.cloudsync.prestashop.com/sync/v1/trigger${full ? '-full' : ''}`, {
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',


### PR DESCRIPTION
# Description

PsEssentials URLs are deprecated. It should have worked until then tho, but it's getting 
hard to diagnose why the CORS is not going up well in the PsxMarketingWithGoogle context, while:

```
❯ curl -s -I "https://eventbus-sync.psessentials.net/sync/trigger-full" | grep origin  
access-control-allow-origin: *
```

# Links

* https://forge.prestashop.com/browse/EB-1304
* https://docs.cloudsync.prestashop.com/api-doc/sync-api#/operations/AuthSyncController_triggerSyncAuth