### PR TITLE
Display links as blocks

### DIFF
--- a/_dev/apps/ui/src/assets/scss/components/_google-issues.scss
+++ b/_dev/apps/ui/src/assets/scss/components/_google-issues.scss
@@ -1,5 +1,7 @@
 .issue-detail {
   .content-element {
+    display:block;
+
     .tooltip {
         position: unset;
       z-index: unset;


### PR DESCRIPTION
## Now

![Screenshot 2024-01-24 at 12-02-54 Product Feed Page _ Disapproved products Page _ Popins - Product Issues ⋅ Storybook](https://github.com/PrestaShopCorp/psxmarketingwithgoogle/assets/6768917/4566237c-cd2e-4528-8b2a-e3a7f10460e8)

## Before

![Screenshot 2024-01-24 at 12-03-05 Product Feed Page _ Disapproved products Page _ Popins - Product Issues ⋅ Storybook](https://github.com/PrestaShopCorp/psxmarketingwithgoogle/assets/6768917/9f3fb3ef-483b-4166-9a45-6fb20202df4c)
