### PR TITLE
Set a limit when loading disapproved products

### DIFF
--- a/_dev/apps/ui/src/store/modules/product-feed/actions.ts
+++ b/_dev/apps/ui/src/store/modules/product-feed/actions.ts
@@ -418,11 +418,17 @@ export default {
     });
   },
 
-  async [ActionsTypes.REQUEST_REPORTING_PRODUCTS_STATUSES]({commit}: Context, nextPage) {
-    const nextToken = nextPage ? `?next_token=${nextPage}` : '';
+  async [ActionsTypes.REQUEST_REPORTING_PRODUCTS_STATUSES](
+    {commit}: Context,
+    nextPage: string|null,
+  ) {
+    const params = new URLSearchParams({
+      next_token: nextPage || '',
+      limit: '10',
+    });
     const result = await (await fetchOnboarding(
       'GET',
-      `product-feeds/validation/list${nextToken}`,
+      `product-feeds/validation/list?${params.toString()}`,
     )).json();
     commit(MutationsTypes.SAVE_ALL_PRODUCTS, result.results);
     return result;


### PR DESCRIPTION
This avoids loading the whole list on the API side