### PR TITLE
Do not try to get json contents from en empty response

### DIFF
--- a/_dev/apps/ui/src/store/modules/campaigns/actions.ts
+++ b/_dev/apps/ui/src/store/modules/campaigns/actions.ts
@@ -177,11 +177,11 @@ export default {
     {}: Context,
     payload: boolean,
   ): Promise<void> {
-    return (await fetchOnboarding(
+    await fetchOnboarding(
       'POST',
       'conversion-actions/enhanced',
       {body: {introduced: payload}},
-    )).json();
+    );
   },
 
   async [ActionsTypes.CREATE_REMARKETING_DEFAULT_CONVERSION_ACTIONS](


### PR DESCRIPTION
`POST conversion-actions/enhanced` returns empty responses. Trying to get the json contents will always fail.