### PR TITLE
chore: Update verification tag retrieval tests to enhance error handling

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -39,7 +39,7 @@ jobs:
       - run: composer install
 
       - name: Run PHP-CS-Fixer
-        run: vendor/bin/php-cs-fixer fix --dry-run
+        uses: prestashopcorp/github-action-php-cs-fixer@master
 
   phpstan:
     name: PHPStan

--- a/_dev/apps/verification-tag/src/verification-tag-retriever.ts
+++ b/_dev/apps/verification-tag/src/verification-tag-retriever.ts
@@ -22,7 +22,7 @@ export const runRetrievalOfVerificationTag = async (
         onResponse: responseHandler,
       },
     )).json();
-      
+
     // 2- Store token in shop
     await fetchShop("setWebsiteVerificationMeta", {
       websiteVerificationMeta: token,
@@ -48,14 +48,18 @@ export const runRetrievalOfVerificationTag = async (
         onResponse: responseHandler,
       },
     );
-  
+
     console.info('Marketing with Google - Google Verification tag has been refreshed.');
     analytics?.track('[GGL] Re-verification & claiming Succeeded');
   } catch (e) {
     console.error('Marketing with Google - Google Verification tag refresh failed.', e);
     analytics?.track('[GGL] Re-verification & claiming Failed');
     scope.setTag('correlationId', correlationId);
-    Sentry.captureException(e, scope);
+
+    // Send error to Sentry if it's not a 403 Forbidden error
+    if (e.code !== 403) {
+      Sentry.captureException(e, scope);
+    }
   }
 };
 
@@ -82,4 +86,3 @@ const responseHandler = async (response: Response) => {
   }
   return response;
 };
-


### PR DESCRIPTION
**Do not send 403 errors to Sentry in verification tag retrieval**

**Update verification tag retrieval tests to enhance error handling**

- Modified the "handles 403 Forbidden error gracefully" test to throw an HttpClientError with a 403 status code.
- Updated the "handles 404 Not Found error" test to throw an HttpClientError with a 404 status code.
- Adjusted the "stops when token retrieval fails" test to throw an HttpClientError with a 500 status code and added an assertion to ensure Sentry.captureException is called.

**Update PHP-CS-Fixer action in GitHub workflow**

- Changed the PHP-CS-Fixer command from a direct run to using the PrestaShop GitHub Action for PHP-CS-Fixer.