### PR TITLE
fix: Do not send 404 errors to Sentry in verification tag retrieval

### DIFF
--- a/_dev/apps/verification-tag/src/verification-tag-retriever.spec.ts
+++ b/_dev/apps/verification-tag/src/verification-tag-retriever.spec.ts
@@ -123,7 +123,7 @@ describe('runRetrievalOfVerificationTag', () => {
     // assert
     expect(fetchOnboardingMock).toBeCalledTimes(1);
     expect(fetchShopMock).toBeCalledTimes(0);
-    expect(Sentry.captureException).toHaveBeenCalled(); // Ensure Sentry is called
+    expect(Sentry.captureException).not.toHaveBeenCalled(); // Ensure Sentry is not called
   });
 
   it('stops when token retrieval fails', async () => {

--- a/_dev/apps/verification-tag/src/verification-tag-retriever.ts
+++ b/_dev/apps/verification-tag/src/verification-tag-retriever.ts
@@ -56,8 +56,8 @@ export const runRetrievalOfVerificationTag = async (
     analytics?.track('[GGL] Re-verification & claiming Failed');
     scope.setTag('correlationId', correlationId);
 
-    // Send error to Sentry if it's not a 403 Forbidden error
-    if (e.code !== 403) {
+    // Send error to Sentry if it's not a 403 or 404 Forbidden error
+    if (e.code !== 403 && e.code !== 404) {
       Sentry.captureException(e, scope);
     }
   }
@@ -65,7 +65,7 @@ export const runRetrievalOfVerificationTag = async (
 
 const responseHandler = async (response: Response) => {
   if (!response.ok) {
-    const error = new HttpClientError(response.statusText, response.status);
+    const error = new HttpClientError('Verification tag refresh failed', response.status);
 
     try {
       const content = await response.text();


### PR DESCRIPTION
- Do not send 404 errors to Sentry in verification tag retrieval
- Set clearer error message