### PR TITLE
fix: summary product count

### DIFF
--- a/_dev/apps/ui/src/components/product-feed/settings/summary/summary.vue
+++ b/_dev/apps/ui/src/components/product-feed/settings/summary/summary.vue
@@ -42,12 +42,9 @@
                     />
                   </template>
                   <div
-                    v-if="productCountStatus === ProductFeedCountStatus.SUCCESS
-                      || moduleNeedUpgradeForProductFilter"
+                    v-if="productCountStatus === ProductFeedCountStatus.SUCCESS"
                   >
-                    {{ moduleNeedUpgradeForProductFilter
-                      ? nextSyncTotalProducts
-                      : productCountToDisplay }}
+                    {{ productCountToDisplay }}
                   </div>
                   <b-alert
                     v-if="productCountStatus === ProductFeedCountStatus.ERROR"
@@ -281,7 +278,6 @@ import productFeedSummaryCard from '@/components/product-feed/summary/product-fe
 import ProductFeedMixin from '@/components/mixins/Product-Feed-Mixin';
 import {ShippingSetupOption} from '@/enums/product-feed/shipping';
 import ActionsTypes from '@/store/modules/product-feed/actions-types';
-import AppGettersTypes from '@/store/modules/app/getters-types';
 import GetterTypes from '@/store/modules/product-feed/getters-types';
 import ProductFeedCountStatus from '@/enums/product-feed/product-feed-count-status';
 import ProductFilterMethodsSynch from '@/enums/product-feed/product-filter-methods-synch';
@@ -309,7 +305,6 @@ export default defineComponent({
       understandTerms: false,
       ProductFeedCountStatus,
       loadingData: true,
-      moduleNeedUpgradeForProductFilter: false,
     };
   },
   computed: {
@@ -475,8 +470,6 @@ export default defineComponent({
   async mounted() {
     this.loadingData = true;
 
-    this.moduleNeedUpgradeForProductFilter = await this.$store.getters[`app/${AppGettersTypes.GET_MODULE_NEED_UPGRADE}`]('psxmarketingwithgoogle', undefined, '1.73.0');
-
     await this.requestShopAttribute().then(() => {
       this.requestAttributeMapping();
     });
@@ -492,11 +485,7 @@ export default defineComponent({
       });
     }
 
-    if (!this.moduleNeedUpgradeForProductFilter) {
-      await this.requestProductCount();
-    } else {
-      await this.requestTotalProductCount();
-    }
+    await this.requestProductCount();
 
     this.loadingData = false;
   },


### PR DESCRIPTION
**Context** :
After a filter is selected in the **product filter** step in the product feed, the total of synchronizable products in the summary page is different from the one displayed in the filter selection.
<img width="1708" height="877" alt="selection_produits" src="https://github.com/user-attachments/assets/da184141-7a76-4168-88b4-7a77bb31dc92" />
<img width="1810" height="901" alt="résumé" src="https://github.com/user-attachments/assets/89ea8fd2-2a89-4c9d-a65b-91d359d4e367" />

**Solution** :
Problem was caused by a retro compatibility feature introduced when the product filter was released.

**Implementation** :
Remove the moduleNeedUpgradeForProductFilter in the component as it is obsolete and buggy.